### PR TITLE
Find branding of a single content item

### DIFF
--- a/src/main/scala/com/gu/commercial/branding/Branding.scala
+++ b/src/main/scala/com/gu/commercial/branding/Branding.scala
@@ -1,0 +1,38 @@
+package com.gu.commercial.branding
+
+import com.gu.contentapi.client.model.v1.Sponsorship
+
+case class Branding(
+  brandingType: BrandingType,
+  sponsor: String,
+  logo: Logo,
+  logoForDarkBackground: Option[Logo]
+)
+
+object Branding {
+  def fromSponsorship(sponsorship: Sponsorship): Branding = Branding(
+    brandingType = BrandingType.fromSponsorshipType(sponsorship.sponsorshipType),
+    sponsor = sponsorship.sponsorName,
+    logo = Logo(
+      src = sponsorship.sponsorLogo,
+      width = sponsorship.sponsorLogoDimensions.map(_.width),
+      height = sponsorship.sponsorLogoDimensions.map(_.height),
+      link = sponsorship.sponsorLink
+    ),
+    logoForDarkBackground = sponsorship.highContrastSponsorLogo.map { src =>
+      Logo(
+        src = src,
+        width = sponsorship.highContrastSponsorLogoDimensions.map(_.width),
+        height = sponsorship.highContrastSponsorLogoDimensions.map(_.height),
+        link = sponsorship.sponsorLink
+      )
+    }
+  )
+}
+
+case class Logo(
+  src: String,
+  width: Option[Int],
+  height: Option[Int],
+  link: String
+)

--- a/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
+++ b/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
@@ -1,0 +1,56 @@
+package com.gu.commercial.branding
+
+import com.gu.contentapi.client.model.v1._
+
+object BrandingFinder {
+
+  import SponsorshipHelper._
+
+  /**
+    * Finds branding of a single content item.
+    *
+    * @param item Content item with <code>section</code> and all <code>tags</code> populated
+    * @param edition eg. <code>uk</code>
+    * @return Branding, if it should be applied, else None
+    */
+  def findItemBranding(item: Content, edition: String): Option[Branding] = {
+    lazy val tagSponsorship = item.tags.flatMap(t => findTagSponsorship(edition, item.webPublicationDate)(t)).headOption
+    lazy val sectionSponsorship = item.section.flatMap(findSectionSponsorship(edition, item.webPublicationDate))
+    (tagSponsorship orElse sectionSponsorship) map Branding.fromSponsorship
+  }
+}
+
+object SponsorshipHelper {
+
+  def isTargetingEdition(edition: String)(sponsorship: Sponsorship): Boolean = {
+    sponsorship.targeting.isEmpty || sponsorship.targeting.exists { t =>
+      t.validEditions.isEmpty || t.validEditions.exists(_.contains(edition.toUpperCase))
+    }
+  }
+
+  def isTargetingDate(date: Option[CapiDateTime])(sponsorship: Sponsorship): Boolean = {
+    def isEarlierOrEqual(optDay1: Option[CapiDateTime], optDay2: Option[CapiDateTime]): Boolean = {
+      val firstIsEarlier = for {
+        d1 <- optDay1
+        d2 <- optDay2
+      } yield d1.dateTime <= d2.dateTime
+      firstIsEarlier getOrElse true
+    }
+    sponsorship.targeting.isEmpty || sponsorship.targeting.exists { t =>
+      isEarlierOrEqual(t.publishedSince, date)
+    }
+  }
+
+  def findSectionSponsorship(edition: String, publishedDate: Option[CapiDateTime])
+    (section: Section): Option[Sponsorship] = {
+    section.activeSponsorships.flatMap(_.find { s =>
+      isTargetingEdition(edition)(s) && isTargetingDate(publishedDate)(s)
+    })
+  }
+
+  def findTagSponsorship(edition: String, publishedDate: Option[CapiDateTime])(tag: Tag): Option[Sponsorship] = {
+    tag.activeSponsorships.flatMap(_.find { s =>
+      isTargetingEdition(edition)(s) && isTargetingDate(publishedDate)(s)
+    })
+  }
+}

--- a/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
+++ b/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
@@ -9,14 +9,18 @@ object BrandingFinder {
   /**
     * Finds branding of a single content item.
     *
-    * @param item Content item with <code>section</code> and all <code>tags</code> populated
+    * @param item    Content item with <code>section</code>, <code>isInappropriateForSponsorship</code> field
+    *                and all <code>tags</code> populated
     * @param edition eg. <code>uk</code>
     * @return Branding, if it should be applied, else None
     */
   def findItemBranding(item: Content, edition: String): Option[Branding] = {
+    val inappropriateForBranding = item.fields.exists(_.isInappropriateForSponsorship.contains(true))
     lazy val tagSponsorship = item.tags.flatMap(t => findTagSponsorship(edition, item.webPublicationDate)(t)).headOption
     lazy val sectionSponsorship = item.section.flatMap(findSectionSponsorship(edition, item.webPublicationDate))
-    (tagSponsorship orElse sectionSponsorship) map Branding.fromSponsorship
+
+    if (inappropriateForBranding) None
+    else (tagSponsorship orElse sectionSponsorship) map Branding.fromSponsorship
   }
 }
 

--- a/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
+++ b/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
@@ -32,17 +32,13 @@ object SponsorshipHelper {
     }
   }
 
-  def isTargetingDate(date: Option[CapiDateTime])(sponsorship: Sponsorship): Boolean = {
-    def isEarlierOrEqual(optDay1: Option[CapiDateTime], optDay2: Option[CapiDateTime]): Boolean = {
-      val firstIsEarlier = for {
-        d1 <- optDay1
-        d2 <- optDay2
-      } yield d1.dateTime <= d2.dateTime
-      firstIsEarlier getOrElse true
-    }
-    sponsorship.targeting.isEmpty || sponsorship.targeting.exists { t =>
-      isEarlierOrEqual(t.publishedSince, date)
-    }
+  def isTargetingDate(optDate: Option[CapiDateTime])(sponsorship: Sponsorship): Boolean = {
+    val dateLaterThanThreshold = for {
+      targeting <- sponsorship.targeting
+      threshold <- targeting.publishedSince
+      date <- optDate
+    } yield date.dateTime >= threshold.dateTime
+    dateLaterThanThreshold getOrElse true
   }
 
   def findSectionSponsorship(edition: String, publishedDate: Option[CapiDateTime])

--- a/src/main/scala/com/gu/commercial/branding/BrandingType.scala
+++ b/src/main/scala/com/gu/commercial/branding/BrandingType.scala
@@ -1,0 +1,29 @@
+package com.gu.commercial.branding
+
+import com.gu.contentapi.client.model.v1.SponsorshipType
+
+sealed trait BrandingType {
+  def name: String
+}
+
+case object Sponsored extends BrandingType {
+  override val name: String = "sponsored"
+}
+
+case object Foundation extends BrandingType {
+  override val name: String = "foundation"
+}
+
+case object PaidContent extends BrandingType {
+  override val name: String = "paid-content"
+}
+
+object BrandingType {
+  def fromSponsorshipType(sponsorshipType: SponsorshipType): BrandingType = {
+    sponsorshipType.name match {
+      case PaidContent.name => PaidContent
+      case Foundation.name => Foundation
+      case _ => Sponsored
+    }
+  }
+}

--- a/src/test/resources/AfterDateTargetedTagBrandedContent.json
+++ b/src/test/resources/AfterDateTargetedTagBrandedContent.json
@@ -1,0 +1,199 @@
+{
+  "id": "football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "type": "audio",
+  "sectionId": "football",
+  "sectionName": "Football",
+  "webPublicationDate": "2016-09-01T20:30:21Z",
+  "webTitle": "Transfer window special – Guardian Australia's Premier League podcast",
+  "webUrl": "https://www.theguardian.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "apiUrl": "https://content.guardianapis.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "tags": [
+    {
+      "id": "football/series/premier-league-the-view-from-australia",
+      "type": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Premier League: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/premier-league-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/premier-league-the-view-from-australia",
+      "references": [
+      ],
+      "description": "<p>A&nbsp;weekly view&nbsp;from Down Under of all things top flight football in England and Wales</p>",
+      "podcast": {
+        "linkUrl": "http://www.theguardian.com",
+        "copyright": "theguardian.com © 2016",
+        "author": "theguardian.com",
+        "subscriptionUrl": "https://itunes.apple.com/au/podcast/premier-league-view-from-australia/id1140387436?mt=2",
+        "explicit": false,
+        "image": "https://uploads.guim.co.uk/2016/08/03/Optus_PodcastBadge3.jpg",
+        "categories": [
+          {
+            "main": "Sports & Recreation",
+            "sub": "Professional"
+          }
+        ]
+      },
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "paid-content",
+          "sponsorName": "ING DIRECT",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/06/Oct/2016/d767ce82-0525-ING_dreamstarter_140.png",
+          "sponsorLink": "https://www.campaigns.ingdirect.com.au/dreamstarter",
+          "targeting": {
+            "publishedSince": "2016-07-04T01:57:12Z"
+          },
+          "sponsorLogoDimensions": {
+            "width": 140,
+            "height": 58
+          }
+        }
+      ]
+    },
+    {
+      "id": "football/football",
+      "type": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Football",
+      "webUrl": "https://www.theguardian.com/football/football",
+      "apiUrl": "https://content.guardianapis.com/football/football",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/series/epl-the-view-from-australia",
+      "type": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/epl-the-view-from-australia",
+      "type": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "sport/australia-sport",
+      "type": "keyword",
+      "sectionId": "sport",
+      "sectionName": "Sport",
+      "webTitle": "Australia sport",
+      "webUrl": "https://www.theguardian.com/sport/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/sport/australia-sport",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/audio",
+      "type": "type",
+      "webTitle": "Audio",
+      "webUrl": "https://www.theguardian.com/audio",
+      "apiUrl": "https://content.guardianapis.com/type/audio",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/podcast",
+      "type": "type",
+      "webTitle": "Podcast",
+      "webUrl": "https://www.theguardian.com/podcasts",
+      "apiUrl": "https://content.guardianapis.com/type/podcast",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/richard-parkin",
+      "type": "contributor",
+      "webTitle": "Richard Parkin",
+      "webUrl": "https://www.theguardian.com/profile/richard-parkin",
+      "apiUrl": "https://content.guardianapis.com/profile/richard-parkin",
+      "references": [
+      ],
+      "bio": "<p>Richard Parkin is a Sydney-based journalist and the casual sport editor at Guardian Australia. He was the football analyst on SBS's The Full Brazilian and is completing a PhD in Political Economy</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/30/1430357903733/140x140Richard_Parkin.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/5/1/1430441131977/Richard-Parkin-R.png",
+      "firstName": "richard",
+      "lastName": "parkin",
+      "twitterHandle": "rrjparkin",
+      "r2ContributorId": "56860"
+    },
+    {
+      "id": "profile/david-squires",
+      "type": "contributor",
+      "webTitle": "David Squires",
+      "webUrl": "https://www.theguardian.com/profile/david-squires",
+      "apiUrl": "https://content.guardianapis.com/profile/david-squires",
+      "references": [
+      ],
+      "firstName": "david",
+      "lastName": "squires",
+      "r2ContributorId": "67060"
+    },
+    {
+      "id": "profile/miketicher",
+      "type": "contributor",
+      "webTitle": "Mike Ticher",
+      "webUrl": "https://www.theguardian.com/profile/miketicher",
+      "apiUrl": "https://content.guardianapis.com/profile/miketicher",
+      "references": [
+      ],
+      "bio": "<p>Mike Ticher is Guardian Australia's news editor. He has worked for the Sydney Morning Herald, the Guardian sports desk in London and was founding editor of independent football magazine When Saturday Comes</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590280939/Mike-Ticher.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590298042/Mike-Ticher-L.png",
+      "firstName": "",
+      "lastName": "ticher",
+      "rcsId": "GNL271742",
+      "r2ContributorId": "16151"
+    },
+    {
+      "id": "profile/miles-martignoni",
+      "type": "contributor",
+      "webTitle": "Miles Martignoni",
+      "webUrl": "https://www.theguardian.com/profile/miles-martignoni",
+      "apiUrl": "https://content.guardianapis.com/profile/miles-martignoni",
+      "references": [
+      ],
+      "bio": "<p>Miles Martignoni is the Podcast Producer at Guardian Australia. Miles tweets at <a href=\" https://twitter.com/milesage\">@milesage</a>. You can email him at <a href=\"mailto:miles.martignoni@theguardian.com \"> miles.martignoni@theguardian.com </a></p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/22/1429700784680/Miles-Martignoni.jpg",
+      "firstName": "miles",
+      "lastName": "martignoni",
+      "twitterHandle": "milesage",
+      "r2ContributorId": "69123"
+    },
+    {
+      "id": "tracking/commissioningdesk/australia-sport",
+      "type": "tracking",
+      "webTitle": "Australia Sport",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/australia-sport",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "football",
+    "webTitle": "Football",
+    "webUrl": "https://www.theguardian.com/football",
+    "apiUrl": "https://content.guardianapis.com/football",
+    "editions": [
+      {
+        "id": "football",
+        "webTitle": "Football",
+        "webUrl": "https://www.theguardian.com/football",
+        "apiUrl": "https://content.guardianapis.com/football",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/resources/BeforeDateTargetedTagBrandedContent.json
+++ b/src/test/resources/BeforeDateTargetedTagBrandedContent.json
@@ -1,0 +1,199 @@
+{
+  "id": "football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "type": "audio",
+  "sectionId": "football",
+  "sectionName": "Football",
+  "webPublicationDate": "2015-09-01T20:30:21Z",
+  "webTitle": "Transfer window special – Guardian Australia's Premier League podcast",
+  "webUrl": "https://www.theguardian.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "apiUrl": "https://content.guardianapis.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "tags": [
+    {
+      "id": "football/series/premier-league-the-view-from-australia",
+      "type": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Premier League: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/premier-league-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/premier-league-the-view-from-australia",
+      "references": [
+      ],
+      "description": "<p>A&nbsp;weekly view&nbsp;from Down Under of all things top flight football in England and Wales</p>",
+      "podcast": {
+        "linkUrl": "http://www.theguardian.com",
+        "copyright": "theguardian.com © 2016",
+        "author": "theguardian.com",
+        "subscriptionUrl": "https://itunes.apple.com/au/podcast/premier-league-view-from-australia/id1140387436?mt=2",
+        "explicit": false,
+        "image": "https://uploads.guim.co.uk/2016/08/03/Optus_PodcastBadge3.jpg",
+        "categories": [
+          {
+            "main": "Sports & Recreation",
+            "sub": "Professional"
+          }
+        ]
+      },
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "paid-content",
+          "sponsorName": "ING DIRECT",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/06/Oct/2016/d767ce82-0525-447f-b6bd-cd436d39e200-ING_dreamstarter_140.png",
+          "sponsorLink": "https://www.campaigns.ingdirect.com.au/dreamstarter",
+          "targeting": {
+            "publishedSince": "2016-07-04T01:57:12Z"
+          },
+          "sponsorLogoDimensions": {
+            "width": 140,
+            "height": 58
+          }
+        }
+      ]
+    },
+    {
+      "id": "football/football",
+      "type": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Football",
+      "webUrl": "https://www.theguardian.com/football/football",
+      "apiUrl": "https://content.guardianapis.com/football/football",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/series/epl-the-view-from-australia",
+      "type": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/epl-the-view-from-australia",
+      "type": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "sport/australia-sport",
+      "type": "keyword",
+      "sectionId": "sport",
+      "sectionName": "Sport",
+      "webTitle": "Australia sport",
+      "webUrl": "https://www.theguardian.com/sport/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/sport/australia-sport",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/audio",
+      "type": "type",
+      "webTitle": "Audio",
+      "webUrl": "https://www.theguardian.com/audio",
+      "apiUrl": "https://content.guardianapis.com/type/audio",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/podcast",
+      "type": "type",
+      "webTitle": "Podcast",
+      "webUrl": "https://www.theguardian.com/podcasts",
+      "apiUrl": "https://content.guardianapis.com/type/podcast",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/richard-parkin",
+      "type": "contributor",
+      "webTitle": "Richard Parkin",
+      "webUrl": "https://www.theguardian.com/profile/richard-parkin",
+      "apiUrl": "https://content.guardianapis.com/profile/richard-parkin",
+      "references": [
+      ],
+      "bio": "<p>Richard Parkin is a Sydney-based journalist and the casual sport editor at Guardian Australia. He was the football analyst on SBS's The Full Brazilian and is completing a PhD in Political Economy</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/30/1430357903733/140x140Richard_Parkin.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/5/1/1430441131977/Richard-Parkin-R.png",
+      "firstName": "richard",
+      "lastName": "parkin",
+      "twitterHandle": "rrjparkin",
+      "r2ContributorId": "56860"
+    },
+    {
+      "id": "profile/david-squires",
+      "type": "contributor",
+      "webTitle": "David Squires",
+      "webUrl": "https://www.theguardian.com/profile/david-squires",
+      "apiUrl": "https://content.guardianapis.com/profile/david-squires",
+      "references": [
+      ],
+      "firstName": "david",
+      "lastName": "squires",
+      "r2ContributorId": "67060"
+    },
+    {
+      "id": "profile/miketicher",
+      "type": "contributor",
+      "webTitle": "Mike Ticher",
+      "webUrl": "https://www.theguardian.com/profile/miketicher",
+      "apiUrl": "https://content.guardianapis.com/profile/miketicher",
+      "references": [
+      ],
+      "bio": "<p>Mike Ticher is Guardian Australia's news editor. He has worked for the Sydney Morning Herald, the Guardian sports desk in London and was founding editor of independent football magazine When Saturday Comes</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590280939/Mike-Ticher.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590298042/Mike-Ticher-L.png",
+      "firstName": "",
+      "lastName": "ticher",
+      "rcsId": "GNL271742",
+      "r2ContributorId": "16151"
+    },
+    {
+      "id": "profile/miles-martignoni",
+      "type": "contributor",
+      "webTitle": "Miles Martignoni",
+      "webUrl": "https://www.theguardian.com/profile/miles-martignoni",
+      "apiUrl": "https://content.guardianapis.com/profile/miles-martignoni",
+      "references": [
+      ],
+      "bio": "<p>Miles Martignoni is the Podcast Producer at Guardian Australia. Miles tweets at <a href=\" https://twitter.com/milesage\">@milesage</a>. You can email him at <a href=\"mailto:miles.martignoni@theguardian.com \"> miles.martignoni@theguardian.com </a></p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/22/1429700784680/Miles-Martignoni.jpg",
+      "firstName": "miles",
+      "lastName": "martignoni",
+      "twitterHandle": "milesage",
+      "r2ContributorId": "69123"
+    },
+    {
+      "id": "tracking/commissioningdesk/australia-sport",
+      "type": "tracking",
+      "webTitle": "Australia Sport",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/australia-sport",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "football",
+    "webTitle": "Football",
+    "webUrl": "https://www.theguardian.com/football",
+    "apiUrl": "https://content.guardianapis.com/football",
+    "editions": [
+      {
+        "id": "football",
+        "webTitle": "Football",
+        "webUrl": "https://www.theguardian.com/football",
+        "apiUrl": "https://content.guardianapis.com/football",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/resources/EditionTargetedTagBrandedContent.json
+++ b/src/test/resources/EditionTargetedTagBrandedContent.json
@@ -1,0 +1,197 @@
+{
+  "id": "football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "type": "audio",
+  "sectionId": "football",
+  "sectionName": "Football",
+  "webPublicationDate": "2016-09-01T20:30:21Z",
+  "webTitle": "Transfer window special – Guardian Australia's Premier League podcast",
+  "webUrl": "https://www.theguardian.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "apiUrl": "https://content.guardianapis.com/football/audio/2016/sep/02/transfer-window-special-guardian-australias-premier-league-podcast",
+  "tags": [
+    {
+      "id": "football/series/premier-league-the-view-from-australia",
+      "type": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Premier League: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/premier-league-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/premier-league-the-view-from-australia",
+      "references": [
+      ],
+      "description": "<p>A&nbsp;weekly view&nbsp;from Down Under of all things top flight football in England and Wales</p>",
+      "podcast": {
+        "linkUrl": "http://www.theguardian.com",
+        "copyright": "theguardian.com © 2016",
+        "author": "theguardian.com",
+        "subscriptionUrl": "https://itunes.apple.com/au/podcast/premier-league-view-from-australia/id1140387436?mt=2",
+        "explicit": false,
+        "image": "https://uploads.guim.co.uk/2016/08/03/Optus_PodcastBadge3.jpg",
+        "categories": [
+          {
+            "main": "Sports & Recreation",
+            "sub": "Professional"
+          }
+        ]
+      },
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "sponsored",
+          "sponsorName": "Optus Premier League: the view from Australia podcast",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/14/Sep/2016/6076c5fb-a3fd-49b8-Optuslogo.jpeg",
+          "sponsorLink": "https://ad.doubleclick.net/ddm/clk/307408916",
+          "targeting": {
+            "validEditions": [
+              "AU"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "football/football",
+      "type": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "Football",
+      "webUrl": "https://www.theguardian.com/football/football",
+      "apiUrl": "https://content.guardianapis.com/football/football",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/series/epl-the-view-from-australia",
+      "type": "series",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/series/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/series/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "football/epl-the-view-from-australia",
+      "type": "keyword",
+      "sectionId": "football",
+      "sectionName": "Football",
+      "webTitle": "EPL: the view from Australia",
+      "webUrl": "https://www.theguardian.com/football/epl-the-view-from-australia",
+      "apiUrl": "https://content.guardianapis.com/football/epl-the-view-from-australia",
+      "references": [
+      ]
+    },
+    {
+      "id": "sport/australia-sport",
+      "type": "keyword",
+      "sectionId": "sport",
+      "sectionName": "Sport",
+      "webTitle": "Australia sport",
+      "webUrl": "https://www.theguardian.com/sport/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/sport/australia-sport",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/audio",
+      "type": "type",
+      "webTitle": "Audio",
+      "webUrl": "https://www.theguardian.com/audio",
+      "apiUrl": "https://content.guardianapis.com/type/audio",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/podcast",
+      "type": "type",
+      "webTitle": "Podcast",
+      "webUrl": "https://www.theguardian.com/podcasts",
+      "apiUrl": "https://content.guardianapis.com/type/podcast",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/richard-parkin",
+      "type": "contributor",
+      "webTitle": "Richard Parkin",
+      "webUrl": "https://www.theguardian.com/profile/richard-parkin",
+      "apiUrl": "https://content.guardianapis.com/profile/richard-parkin",
+      "references": [
+      ],
+      "bio": "<p>Richard Parkin is a Sydney-based journalist and the casual sport editor at Guardian Australia. He was the football analyst on SBS's The Full Brazilian and is completing a PhD in Political Economy</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/4/30/1430357903733/140x140Richard_Parkin.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/5/1/1430441131977/Richard-Parkin-R.png",
+      "firstName": "richard",
+      "lastName": "parkin",
+      "twitterHandle": "rrjparkin",
+      "r2ContributorId": "56860"
+    },
+    {
+      "id": "profile/david-squires",
+      "type": "contributor",
+      "webTitle": "David Squires",
+      "webUrl": "https://www.theguardian.com/profile/david-squires",
+      "apiUrl": "https://content.guardianapis.com/profile/david-squires",
+      "references": [
+      ],
+      "firstName": "david",
+      "lastName": "squires",
+      "r2ContributorId": "67060"
+    },
+    {
+      "id": "profile/miketicher",
+      "type": "contributor",
+      "webTitle": "Mike Ticher",
+      "webUrl": "https://www.theguardian.com/profile/miketicher",
+      "apiUrl": "https://content.guardianapis.com/profile/miketicher",
+      "references": [
+      ],
+      "bio": "<p>Mike Ticher is Guardian Australia's news editor. He has worked for the Sydney Morning Herald, the Guardian sports desk in London and was founding editor of independent football magazine When Saturday Comes</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590280939/Mike-Ticher.jpg",
+      "bylineLargeImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/9/1428590298042/Mike-Ticher-L.png",
+      "firstName": "",
+      "lastName": "ticher",
+      "rcsId": "GNL271742",
+      "r2ContributorId": "16151"
+    },
+    {
+      "id": "profile/miles-martignoni",
+      "type": "contributor",
+      "webTitle": "Miles Martignoni",
+      "webUrl": "https://www.theguardian.com/profile/miles-martignoni",
+      "apiUrl": "https://content.guardianapis.com/profile/miles-martignoni",
+      "references": [
+      ],
+      "bio": "<p>Miles Martignoni is the Podcast Producer at Guardian Australia. Miles tweets at <a href=\" https://twitter.com/milesage\">@milesage</a>. You can email him at <a href=\"mailto:miles.martignoni@theguardian.com \"> miles.martignoni@theguardian.com </a></p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/contributor/2015/4/22/1429700784680/Miles-Martignoni.jpg",
+      "firstName": "miles",
+      "lastName": "martignoni",
+      "twitterHandle": "milesage",
+      "r2ContributorId": "69123"
+    },
+    {
+      "id": "tracking/commissioningdesk/australia-sport",
+      "type": "tracking",
+      "webTitle": "Australia Sport",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/australia-sport",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/australia-sport",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "football",
+    "webTitle": "Football",
+    "webUrl": "https://www.theguardian.com/football",
+    "apiUrl": "https://content.guardianapis.com/football",
+    "editions": [
+      {
+        "id": "football",
+        "webTitle": "Football",
+        "webUrl": "https://www.theguardian.com/football",
+        "apiUrl": "https://content.guardianapis.com/football",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/resources/InappropriateContent.json
+++ b/src/test/resources/InappropriateContent.json
@@ -1,0 +1,179 @@
+{
+  "id": "sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "type": "article",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webPublicationDate": "2017-01-04T07:00:17Z",
+  "webTitle": "Coffee from Rainforest Alliance farms in Brazil linked to exploited workers",
+  "webUrl": "https://www.theguardian.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "fields": {
+    "isInappropriateForSponsorship": "true"
+  },
+  "tags": [
+    {
+      "id": "sustainable-business/sustainable-business",
+      "type": "keyword",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Guardian sustainable business",
+      "webUrl": "https://www.theguardian.com/sustainable-business/sustainable-business",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/sustainable-business",
+      "references": [
+      ]
+    },
+    {
+      "id": "sustainable-business/series/spotlight-on-commodities",
+      "type": "series",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Spotlight on commodities",
+      "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-commodities",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-commodities",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "sponsored",
+          "sponsorName": "Fairtrade Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          "sponsorLink": "http://www.fairtrade.org.uk/"
+        }
+      ]
+    },
+    {
+      "id": "world/brazil",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Brazil",
+      "webUrl": "https://www.theguardian.com/world/brazil",
+      "apiUrl": "https://content.guardianapis.com/world/brazil",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/americas",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Americas",
+      "webUrl": "https://www.theguardian.com/world/americas",
+      "apiUrl": "https://content.guardianapis.com/world/americas",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "lifeandstyle/coffee",
+      "type": "keyword",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Coffee",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/coffee",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/coffee",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/global-development",
+      "type": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Global development",
+      "webUrl": "https://www.theguardian.com/global-development/global-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/global-development",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/fair-trade",
+      "type": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Fair trade",
+      "webUrl": "https://www.theguardian.com/global-development/fair-trade",
+      "apiUrl": "https://content.guardianapis.com/global-development/fair-trade",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on fair trade, the the Fairtrade Foundation and trading conditions in developing countries</p>"
+    },
+    {
+      "id": "environment/environment",
+      "type": "keyword",
+      "sectionId": "environment",
+      "sectionName": "Environment",
+      "webTitle": "Environment",
+      "webUrl": "https://www.theguardian.com/environment/environment",
+      "apiUrl": "https://content.guardianapis.com/environment/environment",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/article",
+      "type": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/news",
+      "type": "tone",
+      "webTitle": "News",
+      "webUrl": "https://www.theguardian.com/tone/news",
+      "apiUrl": "https://content.guardianapis.com/tone/news",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/dom-phillips",
+      "type": "contributor",
+      "webTitle": "Dom Phillips",
+      "webUrl": "https://www.theguardian.com/profile/dom-phillips",
+      "apiUrl": "https://content.guardianapis.com/profile/dom-phillips",
+      "references": [
+      ],
+      "bio": "<p>Dom Phillips is a British journalist who has been based in Brazil since 2007. A former Mixmag editor, his book Superstar DJs Here We Go was published in 2009. Twitter @domphillips</p>",
+      "firstName": "dom",
+      "lastName": "phillips",
+      "r2ContributorId": "59208"
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-professional-networks",
+      "type": "tracking",
+      "webTitle": "UK Professional Networks",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-professional-networks",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-professional-networks",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "sustainable-business",
+    "webTitle": "Guardian Sustainable Business",
+    "webUrl": "https://www.theguardian.com/sustainable-business",
+    "apiUrl": "https://content.guardianapis.com/sustainable-business",
+    "editions": [
+      {
+        "id": "sustainable-business",
+        "webTitle": "Guardian Sustainable Business",
+        "webUrl": "https://www.theguardian.com/sustainable-business",
+        "apiUrl": "https://content.guardianapis.com/sustainable-business",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/resources/SectionAndTagBrandedContent.json
+++ b/src/test/resources/SectionAndTagBrandedContent.json
@@ -1,0 +1,219 @@
+{
+  "id": "cities/2015/aug/13/can-the-safecity-app-make-delhi-safer-for-women",
+  "type": "article",
+  "sectionId": "cities",
+  "sectionName": "Cities",
+  "webPublicationDate": "2015-08-13T11:03:19Z",
+  "webTitle": "Can the Safecity app make Delhi safer for women?",
+  "webUrl": "https://www.theguardian.com/cities/2015/aug/13/can-the-safecity-app-make-delhi-safer-for-women",
+  "apiUrl": "https://content.guardianapis.com/cities/2015/aug/13/can-the-safecity-app-make-delhi-safer-for-women",
+  "tags": [
+    {
+      "id": "cities/series/tech-and-the-city",
+      "type": "series",
+      "sectionId": "cities",
+      "sectionName": "Cities",
+      "webTitle": "Tech and the city",
+      "webUrl": "https://www.theguardian.com/cities/series/tech-and-the-city",
+      "apiUrl": "https://content.guardianapis.com/cities/series/tech-and-the-city",
+      "references": [
+
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "sponsored",
+          "sponsorName": "Fairtrade Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          "sponsorLink": "http://www.fairtrade.org.uk/"
+        }
+      ]
+    },
+    {
+      "id": "cities/cities",
+      "type": "keyword",
+      "sectionId": "cities",
+      "sectionName": "Cities",
+      "webTitle": "Cities",
+      "webUrl": "https://www.theguardian.com/cities/cities",
+      "apiUrl": "https://content.guardianapis.com/cities/cities",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "world/india",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "India",
+      "webUrl": "https://www.theguardian.com/world/india",
+      "apiUrl": "https://content.guardianapis.com/world/india",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "lifeandstyle/women",
+      "type": "keyword",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Women",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/women",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/women",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "world/delhi",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Delhi",
+      "webUrl": "https://www.theguardian.com/world/delhi",
+      "apiUrl": "https://content.guardianapis.com/world/delhi",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "technology/technology",
+      "type": "keyword",
+      "sectionId": "technology",
+      "sectionName": "Technology",
+      "webTitle": "Technology",
+      "webUrl": "https://www.theguardian.com/technology/technology",
+      "apiUrl": "https://content.guardianapis.com/technology/technology",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "world/world",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "world/south-and-central-asia",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "South and Central Asia",
+      "webUrl": "https://www.theguardian.com/world/south-and-central-asia",
+      "apiUrl": "https://content.guardianapis.com/world/south-and-central-asia",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "technology/apps",
+      "type": "keyword",
+      "sectionId": "technology",
+      "sectionName": "Technology",
+      "webTitle": "Apps",
+      "webUrl": "https://www.theguardian.com/technology/apps",
+      "apiUrl": "https://content.guardianapis.com/technology/apps",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "society/rape",
+      "type": "keyword",
+      "sectionId": "society",
+      "sectionName": "Society",
+      "webTitle": "Rape and sexual assault",
+      "webUrl": "https://www.theguardian.com/society/rape",
+      "apiUrl": "https://content.guardianapis.com/society/rape",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "society/society",
+      "type": "keyword",
+      "sectionId": "society",
+      "sectionName": "Society",
+      "webTitle": "Society",
+      "webUrl": "https://www.theguardian.com/society/society",
+      "apiUrl": "https://content.guardianapis.com/society/society",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "type/article",
+      "type": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "tone/news",
+      "type": "tone",
+      "webTitle": "News",
+      "webUrl": "https://www.theguardian.com/tone/news",
+      "apiUrl": "https://content.guardianapis.com/tone/news",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "profile/ellie-violet-bramley",
+      "type": "contributor",
+      "webTitle": "Ellie Violet Bramley",
+      "webUrl": "https://www.theguardian.com/profile/ellie-violet-bramley",
+      "apiUrl": "https://content.guardianapis.com/profile/ellie-violet-bramley",
+      "references": [
+
+      ],
+      "bio": "<p><br />Ellie is a freelance journalist. She writes mainly on culture, cities, women's issues and, all too often, Point Break. She has experience working in the UK and Middle East, having been culture editor of a Lebanese news site based in Beirut. As well as the Guardian she has written for the BBC, Creative Review and Time Out, amongst others. She tweets – <a href=\"https://twitter.com/ellsviolet\">@ellsviolet</a></p>",
+      "firstName": "bramley",
+      "lastName": "ellie",
+      "r2ContributorId": "60379"
+    }
+  ],
+  "section": {
+    "id": "cities",
+    "webTitle": "Cities",
+    "webUrl": "https://www.theguardian.com/cities",
+    "apiUrl": "https://content.guardianapis.com/cities",
+    "editions": [
+      {
+        "id": "cities",
+        "webTitle": "Cities",
+        "webUrl": "https://www.theguardian.com/cities",
+        "apiUrl": "https://content.guardianapis.com/cities",
+        "code": "default"
+      }
+    ],
+    "activeSponsorships": [
+      {
+        "sponsorshipType": "foundation",
+        "sponsorName": "Rockefeller Foundation",
+        "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
+        "sponsorLink": "http://www.100resilientcities.org/?source=100RC_Guardian_Banner_9.22&utm_medium=display&utm_campaign=100RC_Guardian_Banner_9.22",
+        "sponsorLogoDimensions": {
+          "width": 140,
+          "height": 37
+        },
+        "highContrastSponsorLogo": "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-dcedb4a87cad-Rock_white.png",
+        "highContrastSponsorLogoDimensions": {
+          "width": 140,
+          "height": 47
+        }
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/resources/SectionBrandedContent.json
+++ b/src/test/resources/SectionBrandedContent.json
@@ -1,0 +1,176 @@
+{
+  "id": "cities/2017/jan/17/congo-rivalry-kinshasa-brazzaville-river-drc",
+  "type": "article",
+  "sectionId": "cities",
+  "sectionName": "Cities",
+  "webPublicationDate": "2017-01-17T07:15:32Z",
+  "webTitle": "Face-off over the Congo: the long rivalry between Kinshasa and Brazzaville",
+  "webUrl": "https://www.theguardian.com/cities/2017/jan/17/congo-rivalry-kinshasa-brazzaville-river-drc",
+  "apiUrl": "https://content.guardianapis.com/cities/2017/jan/17/congo-rivalry-kinshasa-brazzaville-river-drc",
+  "tags": [
+    {
+      "id": "cities/cities",
+      "type": "keyword",
+      "sectionId": "cities",
+      "sectionName": "Cities",
+      "webTitle": "Cities",
+      "webUrl": "https://www.theguardian.com/cities/cities",
+      "apiUrl": "https://content.guardianapis.com/cities/cities",
+      "references": [
+      ]
+    },
+    {
+      "id": "cities/series/border-cities",
+      "type": "series",
+      "sectionId": "cities",
+      "sectionName": "Cities",
+      "webTitle": "Border cities",
+      "webUrl": "https://www.theguardian.com/cities/series/border-cities",
+      "apiUrl": "https://content.guardianapis.com/cities/series/border-cities",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/congo-brazzaville",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Congo-Brazzaville",
+      "webUrl": "https://www.theguardian.com/world/congo-brazzaville",
+      "apiUrl": "https://content.guardianapis.com/world/congo-brazzaville",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/congo",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Democratic Republic of the Congo",
+      "webUrl": "https://www.theguardian.com/world/congo",
+      "apiUrl": "https://content.guardianapis.com/world/congo",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/africa",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Africa",
+      "webUrl": "https://www.theguardian.com/world/africa",
+      "apiUrl": "https://content.guardianapis.com/world/africa",
+      "references": [
+      ]
+    },
+    {
+      "id": "politics/politics",
+      "type": "keyword",
+      "sectionId": "politics",
+      "sectionName": "Politics",
+      "webTitle": "Politics",
+      "webUrl": "https://www.theguardian.com/politics/politics",
+      "apiUrl": "https://content.guardianapis.com/politics/politics",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/conflict-and-development",
+      "type": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Conflict and development",
+      "webUrl": "https://www.theguardian.com/global-development/conflict-and-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/conflict-and-development",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on conflict, tribal conflict, war including civil war and violence in developing countries&nbsp;</p>"
+    },
+    {
+      "id": "type/article",
+      "type": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/features",
+      "type": "tone",
+      "webTitle": "Features",
+      "webUrl": "https://www.theguardian.com/tone/features",
+      "apiUrl": "https://content.guardianapis.com/tone/features",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/jasonburke",
+      "type": "contributor",
+      "webTitle": "Jason Burke",
+      "webUrl": "https://www.theguardian.com/profile/jasonburke",
+      "apiUrl": "https://content.guardianapis.com/profile/jasonburke",
+      "references": [
+      ],
+      "bio": "<p>Jason is the Africa&nbsp; correspondent of the Guardian, based in<br>\nJohannesburg, and reporting from across the continent. In 20 years as<br>\na foreign correspondent, he has covered stories throughout the Middle<br>\nEast, Europe and South Asia. He has written extensively on Islamic<br>\nextremism and, among numerous other conflicts, covered the wars of<br>\n2001 in Afghanistan and 2003 in Iraq. Jason is the author of four<br>\nbooks, most recently <a href=\"http://bookshop.theguardian.com/catalog/product/view/id/320779/bookshop.theguardian.com/catalog/product/view/id/320779/\">The New Threat</a>.</p>",
+      "bylineImageUrl": "https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2010/3/2/1267538178716/Jason-Burke.jpg",
+      "firstName": "",
+      "lastName": "burke",
+      "rcsId": "GNL001549",
+      "r2ContributorId": "15798"
+    },
+    {
+      "id": "tracking/commissioningdesk/cities",
+      "type": "tracking",
+      "webTitle": "Cities",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/cities",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/cities",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "cities",
+    "webTitle": "Cities",
+    "webUrl": "https://www.theguardian.com/cities",
+    "apiUrl": "https://content.guardianapis.com/cities",
+    "editions": [
+      {
+        "id": "cities",
+        "webTitle": "Cities",
+        "webUrl": "https://www.theguardian.com/cities",
+        "apiUrl": "https://content.guardianapis.com/cities",
+        "code": "default"
+      }
+    ],
+    "activeSponsorships": [
+      {
+        "sponsorshipType": "foundation",
+        "sponsorName": "Rockefeller Foundation",
+        "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
+        "sponsorLink": "http://www.100resilientcities.org/",
+        "sponsorLogoDimensions": {
+          "width": 140,
+          "height": 37
+        },
+        "highContrastSponsorLogo": "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-Rock_white.png",
+        "highContrastSponsorLogoDimensions": {
+          "width": 140,
+          "height": 47
+        }
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/resources/TagBrandedContent-MultipleBrands.json
+++ b/src/test/resources/TagBrandedContent-MultipleBrands.json
@@ -1,0 +1,193 @@
+{
+  "id": "sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "type": "article",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webPublicationDate": "2017-01-04T07:00:17Z",
+  "webTitle": "Coffee from Rainforest Alliance farms in Brazil linked to exploited workers",
+  "webUrl": "https://www.theguardian.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "tags": [
+    {
+      "id": "sustainable-business/sustainable-business",
+      "type": "keyword",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Guardian sustainable business",
+      "webUrl": "https://www.theguardian.com/sustainable-business/sustainable-business",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/sustainable-business",
+      "references": [
+      ]
+    },
+    {
+      "id": "sustainable-business/series/spotlight-on-commodities",
+      "type": "series",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Spotlight on commodities",
+      "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-commodities",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-commodities",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "sponsored",
+          "sponsorName": "Fairtrade Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          "sponsorLink": "http://www.fairtrade.org.uk/"
+        }
+      ]
+    },
+    {
+      "id": "world/brazil",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Brazil",
+      "webUrl": "https://www.theguardian.com/world/brazil",
+      "apiUrl": "https://content.guardianapis.com/world/brazil",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "foundation",
+          "sponsorName": "Rockefeller Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
+          "sponsorLink": "http://www.100resilientcities.org/",
+          "sponsorLogoDimensions": {
+            "width": 140,
+            "height": 37
+          },
+          "highContrastSponsorLogo": "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-Rock_white.png",
+          "highContrastSponsorLogoDimensions": {
+            "width": 140,
+            "height": 47
+          }
+        }
+      ]
+    },
+    {
+      "id": "world/americas",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Americas",
+      "webUrl": "https://www.theguardian.com/world/americas",
+      "apiUrl": "https://content.guardianapis.com/world/americas",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "lifeandstyle/coffee",
+      "type": "keyword",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Coffee",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/coffee",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/coffee",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/global-development",
+      "type": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Global development",
+      "webUrl": "https://www.theguardian.com/global-development/global-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/global-development",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/fair-trade",
+      "type": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Fair trade",
+      "webUrl": "https://www.theguardian.com/global-development/fair-trade",
+      "apiUrl": "https://content.guardianapis.com/global-development/fair-trade",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on fair trade, the the Fairtrade Foundation and trading conditions in developing countries</p>"
+    },
+    {
+      "id": "environment/environment",
+      "type": "keyword",
+      "sectionId": "environment",
+      "sectionName": "Environment",
+      "webTitle": "Environment",
+      "webUrl": "https://www.theguardian.com/environment/environment",
+      "apiUrl": "https://content.guardianapis.com/environment/environment",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/article",
+      "type": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/news",
+      "type": "tone",
+      "webTitle": "News",
+      "webUrl": "https://www.theguardian.com/tone/news",
+      "apiUrl": "https://content.guardianapis.com/tone/news",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/dom-phillips",
+      "type": "contributor",
+      "webTitle": "Dom Phillips",
+      "webUrl": "https://www.theguardian.com/profile/dom-phillips",
+      "apiUrl": "https://content.guardianapis.com/profile/dom-phillips",
+      "references": [
+      ],
+      "bio": "<p>Dom Phillips is a British journalist who has been based in Brazil since 2007. A former Mixmag editor, his book Superstar DJs Here We Go was published in 2009. Twitter @domphillips</p>",
+      "firstName": "dom",
+      "lastName": "phillips",
+      "r2ContributorId": "59208"
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-professional-networks",
+      "type": "tracking",
+      "webTitle": "UK Professional Networks",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-professional-networks",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-professional-networks",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "sustainable-business",
+    "webTitle": "Guardian Sustainable Business",
+    "webUrl": "https://www.theguardian.com/sustainable-business",
+    "apiUrl": "https://content.guardianapis.com/sustainable-business",
+    "editions": [
+      {
+        "id": "sustainable-business",
+        "webTitle": "Guardian Sustainable Business",
+        "webUrl": "https://www.theguardian.com/sustainable-business",
+        "apiUrl": "https://content.guardianapis.com/sustainable-business",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/resources/TagBrandedContent.json
+++ b/src/test/resources/TagBrandedContent.json
@@ -1,0 +1,176 @@
+{
+  "id": "sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "type": "article",
+  "sectionId": "sustainable-business",
+  "sectionName": "Guardian Sustainable Business",
+  "webPublicationDate": "2017-01-04T07:00:17Z",
+  "webTitle": "Coffee from Rainforest Alliance farms in Brazil linked to exploited workers",
+  "webUrl": "https://www.theguardian.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "apiUrl": "https://content.guardianapis.com/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay",
+  "tags": [
+    {
+      "id": "sustainable-business/sustainable-business",
+      "type": "keyword",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Guardian sustainable business",
+      "webUrl": "https://www.theguardian.com/sustainable-business/sustainable-business",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/sustainable-business",
+      "references": [
+      ]
+    },
+    {
+      "id": "sustainable-business/series/spotlight-on-commodities",
+      "type": "series",
+      "sectionId": "sustainable-business",
+      "sectionName": "Guardian Sustainable Business",
+      "webTitle": "Spotlight on commodities",
+      "webUrl": "https://www.theguardian.com/sustainable-business/series/spotlight-on-commodities",
+      "apiUrl": "https://content.guardianapis.com/sustainable-business/series/spotlight-on-commodities",
+      "references": [
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "sponsored",
+          "sponsorName": "Fairtrade Foundation",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+          "sponsorLink": "http://www.fairtrade.org.uk/"
+        }
+      ]
+    },
+    {
+      "id": "world/brazil",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Brazil",
+      "webUrl": "https://www.theguardian.com/world/brazil",
+      "apiUrl": "https://content.guardianapis.com/world/brazil",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/americas",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "Americas",
+      "webUrl": "https://www.theguardian.com/world/americas",
+      "apiUrl": "https://content.guardianapis.com/world/americas",
+      "references": [
+      ]
+    },
+    {
+      "id": "world/world",
+      "type": "keyword",
+      "sectionId": "world",
+      "sectionName": "World news",
+      "webTitle": "World news",
+      "webUrl": "https://www.theguardian.com/world/world",
+      "apiUrl": "https://content.guardianapis.com/world/world",
+      "references": [
+      ]
+    },
+    {
+      "id": "lifeandstyle/coffee",
+      "type": "keyword",
+      "sectionId": "lifeandstyle",
+      "sectionName": "Life and style",
+      "webTitle": "Coffee",
+      "webUrl": "https://www.theguardian.com/lifeandstyle/coffee",
+      "apiUrl": "https://content.guardianapis.com/lifeandstyle/coffee",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/global-development",
+      "type": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Global development",
+      "webUrl": "https://www.theguardian.com/global-development/global-development",
+      "apiUrl": "https://content.guardianapis.com/global-development/global-development",
+      "references": [
+      ]
+    },
+    {
+      "id": "global-development/fair-trade",
+      "type": "keyword",
+      "sectionId": "global-development",
+      "sectionName": "Global development",
+      "webTitle": "Fair trade",
+      "webUrl": "https://www.theguardian.com/global-development/fair-trade",
+      "apiUrl": "https://content.guardianapis.com/global-development/fair-trade",
+      "references": [
+      ],
+      "description": "<p>News, comment and features on fair trade, the the Fairtrade Foundation and trading conditions in developing countries</p>"
+    },
+    {
+      "id": "environment/environment",
+      "type": "keyword",
+      "sectionId": "environment",
+      "sectionName": "Environment",
+      "webTitle": "Environment",
+      "webUrl": "https://www.theguardian.com/environment/environment",
+      "apiUrl": "https://content.guardianapis.com/environment/environment",
+      "references": [
+      ]
+    },
+    {
+      "id": "type/article",
+      "type": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+      ]
+    },
+    {
+      "id": "tone/news",
+      "type": "tone",
+      "webTitle": "News",
+      "webUrl": "https://www.theguardian.com/tone/news",
+      "apiUrl": "https://content.guardianapis.com/tone/news",
+      "references": [
+      ]
+    },
+    {
+      "id": "profile/dom-phillips",
+      "type": "contributor",
+      "webTitle": "Dom Phillips",
+      "webUrl": "https://www.theguardian.com/profile/dom-phillips",
+      "apiUrl": "https://content.guardianapis.com/profile/dom-phillips",
+      "references": [
+      ],
+      "bio": "<p>Dom Phillips is a British journalist who has been based in Brazil since 2007. A former Mixmag editor, his book Superstar DJs Here We Go was published in 2009. Twitter @domphillips</p>",
+      "firstName": "dom",
+      "lastName": "phillips",
+      "r2ContributorId": "59208"
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-professional-networks",
+      "type": "tracking",
+      "webTitle": "UK Professional Networks",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-professional-networks",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-professional-networks",
+      "references": [
+      ]
+    }
+  ],
+  "section": {
+    "id": "sustainable-business",
+    "webTitle": "Guardian Sustainable Business",
+    "webUrl": "https://www.theguardian.com/sustainable-business",
+    "apiUrl": "https://content.guardianapis.com/sustainable-business",
+    "editions": [
+      {
+        "id": "sustainable-business",
+        "webTitle": "Guardian Sustainable Business",
+        "webUrl": "https://www.theguardian.com/sustainable-business",
+        "apiUrl": "https://content.guardianapis.com/sustainable-business",
+        "code": "default"
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -18,6 +18,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       case JField("sponsorshipType", v) => JField("sponsorshipTypeName", v)
       case JField("webPublicationDate", v) => JField("publicationDateText", v)
       case JField("publishedSince", v) => JField("publishedSinceText", v)
+      case JField("isInappropriateForSponsorship", v) => JField("isInappropriateForSponsorshipText", v)
     }.extract[StubItem]
   }
 
@@ -28,6 +29,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
   private def getEditionTargetedTagBrandedItem = brandedItem("EditionTargetedTagBrandedContent.json")
   private def getBeforeDateTargetedTagBrandedItem = brandedItem("BeforeDateTargetedTagBrandedContent.json")
   private def getAfterDateTargetedTagBrandedItem = brandedItem("AfterDateTargetedTagBrandedContent.json")
+  private def getInappropriateItem = brandedItem("InappropriateContent.json")
 
   "findItemBranding" should "give branding of tag for content with a single branded tag" in {
     val item = getTagBrandedItem
@@ -138,6 +140,12 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
 
   it should "give no branding for content published before the threshold date" in {
     val item = getBeforeDateTargetedTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding should be(None)
+  }
+
+  it should "give no branding for content with the isInappropriateForSponsorship flag" in {
+    val item = getInappropriateItem
     val branding = BrandingFinder.findItemBranding(item, edition = "uk")
     branding should be(None)
   }

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -69,14 +69,14 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       sponsor = "Rockefeller Foundation",
       logo = Logo(
         src = "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
-        width = None,
-        height = None,
+        width = Some(140),
+        height = Some(37),
         link = "http://www.100resilientcities.org/"
       ),
       logoForDarkBackground = Some(Logo(
         src = "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-Rock_white.png",
-        width = None,
-        height = None,
+        width = Some(140),
+        height = Some(47),
         link = "http://www.100resilientcities.org/"
       ))
     ))
@@ -128,8 +128,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       sponsor = "ING DIRECT",
       logo = Logo(
         src = "https://static.theguardian.com/commercial/sponsor/06/Oct/2016/d767ce82-0525-ING_dreamstarter_140.png",
-        width = None,
-        height = None,
+        width = Some(140),
+        height = Some(58),
         link = "https://www.campaigns.ingdirect.com.au/dreamstarter"
       ),
       logoForDarkBackground = None

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -1,0 +1,151 @@
+package com.gu.commercial.branding
+
+import com.gu.commercial.branding.TestModel.StubItem
+import net.liftweb.json
+import net.liftweb.json.JsonAST.JField
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+import scala.io.Source
+
+class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
+
+  private implicit val jsonFormats = json.DefaultFormats
+
+  private def brandedItem(fileName: String) = {
+    val s = Source.fromURL(getClass.getResource(s"/$fileName")).mkString
+    val j = json.parse(s)
+    j.transform {
+      case JField("sponsorshipType", v) => JField("sponsorshipTypeName", v)
+      case JField("webPublicationDate", v) => JField("publicationDateText", v)
+      case JField("publishedSince", v) => JField("publishedSinceText", v)
+    }.extract[StubItem]
+  }
+
+  private def getTagBrandedItem = brandedItem("TagBrandedContent.json")
+  private def getMultipleTagBrandedItem = brandedItem("TagBrandedContent-MultipleBrands.json")
+  private def getSectionBrandedItem = brandedItem("SectionBrandedContent.json")
+  private def getSectionAndTagBrandedItem = brandedItem("SectionAndTagBrandedContent.json")
+  private def getEditionTargetedTagBrandedItem = brandedItem("EditionTargetedTagBrandedContent.json")
+  private def getBeforeDateTargetedTagBrandedItem = brandedItem("BeforeDateTargetedTagBrandedContent.json")
+  private def getAfterDateTargetedTagBrandedItem = brandedItem("AfterDateTargetedTagBrandedContent.json")
+
+  "findItemBranding" should "give branding of tag for content with a single branded tag" in {
+    val item = getTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding.value should be(Branding(
+      brandingType = Sponsored,
+      sponsor = "Fairtrade Foundation",
+      logo = Logo(
+        src = "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+        width = None,
+        height = None,
+      link = "http://www.fairtrade.org.uk/"
+      ),
+      logoForDarkBackground = None
+    ))
+  }
+
+  it should "give branding of first matching branded tag for content with multiple branded tags" in {
+    val item = getMultipleTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding.value should be(Branding(
+      brandingType = Sponsored,
+      sponsor = "Fairtrade Foundation",
+      logo = Logo(
+        src = "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+        width = None,
+        height = None,
+        link = "http://www.fairtrade.org.uk/"
+      ),
+      logoForDarkBackground = None
+    ))
+  }
+
+  it should "give section branding for content in a branded section" in {
+    val item = getSectionBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding.value should be(Branding(
+      brandingType = Sponsored,
+      sponsor = "Rockefeller Foundation",
+      logo = Logo(
+        src = "https://static.theguardian.com/commercial/sponsor/cities/cities/logo.png",
+        width = None,
+        height = None,
+        link = "http://www.100resilientcities.org/"
+      ),
+      logoForDarkBackground = Some(Logo(
+        src = "https://static.theguardian.com/commercial/sponsor/19/Oct/2016/4369caea-6271-4ddf-ad67-Rock_white.png",
+        width = None,
+        height = None,
+        link = "http://www.100resilientcities.org/"
+      ))
+    ))
+  }
+
+  it should "give branding of tag for content in a branded section and with a branded tag" in {
+    val item = getSectionAndTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding.value should be(Branding(
+      brandingType = Sponsored,
+      sponsor = "Fairtrade Foundation",
+      logo = Logo(
+        src = "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
+        width = None,
+        height = None,
+        link = "http://www.fairtrade.org.uk/"
+      ),
+      logoForDarkBackground = None
+    ))
+  }
+
+  it should "give AU edition branding for content in AU edition with a branded tag in AU edition" in {
+    val item = getEditionTargetedTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "au")
+    branding.value should be(Branding(
+      brandingType = Sponsored,
+      sponsor = "Optus Premier League: the view from Australia podcast",
+      logo = Logo(
+        src = "https://static.theguardian.com/commercial/sponsor/14/Sep/2016/6076c5fb-a3fd-49b8-Optuslogo.jpeg",
+        width = None,
+        height = None,
+        link = "https://ad.doubleclick.net/ddm/clk/307408916"
+      ),
+      logoForDarkBackground = None
+    ))
+  }
+
+  it should "give no branding for content in UK edition with a branded tag in AU edition" in {
+    val item = getEditionTargetedTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding should be(None)
+  }
+
+  it should "give branding for content published after the threshold date" in {
+    val item = getAfterDateTargetedTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding.value should be(Branding(
+      brandingType = Sponsored,
+      sponsor = "ING DIRECT",
+      logo = Logo(
+        src = "https://static.theguardian.com/commercial/sponsor/06/Oct/2016/d767ce82-0525-ING_dreamstarter_140.png",
+        width = None,
+        height = None,
+        link = "https://www.campaigns.ingdirect.com.au/dreamstarter"
+      ),
+      logoForDarkBackground = None
+    ))
+  }
+
+  it should "give no branding for content published before the threshold date" in {
+    val item = getBeforeDateTargetedTagBrandedItem
+    val branding = BrandingFinder.findItemBranding(item, edition = "uk")
+    branding should be(None)
+  }
+
+
+  "findItemSetBranding" should "give branding if all items in set have same branding" is pending
+
+  "findSectionBranding" should "give section branding for a branded section result" is pending
+
+  "findTagBranding" should "give tag branding for a branded tag result" is pending
+}

--- a/src/test/scala/com/gu/commercial/branding/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/branding/TestModel.scala
@@ -1,0 +1,95 @@
+package com.gu.commercial.branding
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+import com.gu.contentapi.client.model.v1._
+
+object TestModel {
+
+  private def dateTextToCapiDateTime(s: String): CapiDateTime = TestCapiDateTime(
+    dateTime = LocalDateTime.parse(s, ISO_OFFSET_DATE_TIME).toInstant(UTC).toEpochMilli,
+    iso8601 = s
+  )
+
+  case class TestCapiDateTime(dateTime: Long, iso8601: String) extends CapiDateTime
+
+  case class TestSponsorshipTargeting(
+    publishedSinceText: Option[String],
+    validEditions: Option[Seq[String]]
+  ) extends SponsorshipTargeting {
+    def publishedSince: Option[CapiDateTime] = publishedSinceText.map(dateTextToCapiDateTime)
+  }
+
+  case class TestSponsorship(
+    sponsorshipTypeName: String,
+    sponsorName: String,
+    sponsorLogo: String,
+    sponsorLink: String,
+    targeting: Option[TestSponsorshipTargeting],
+    aboutLink: Option[String],
+    sponsorLogoDimensions: Option[SponsorshipLogoDimensions],
+    highContrastSponsorLogo: Option[String],
+    highContrastSponsorLogoDimensions: Option[SponsorshipLogoDimensions]
+  ) extends Sponsorship {
+    def sponsorshipType: SponsorshipType = sponsorshipTypeName match {
+      case "sponsored" => SponsorshipType.Sponsored
+      case "paid-content" => SponsorshipType.PaidContent
+      case "foundation" => SponsorshipType.Foundation
+    }
+  }
+
+  case class StubSection(id: String, activeSponsorships: Option[Seq[TestSponsorship]]) extends Section {
+    def webTitle: String = ""
+    def webUrl: String = ""
+    def apiUrl: String = ""
+    def editions: Seq[Edition] = Nil
+  }
+
+  case class StubTag(id: String, activeSponsorships: Option[Seq[TestSponsorship]]) extends Tag {
+    def `type`: TagType = TagType.Keyword
+    def sectionId: Option[String] = None
+    def sectionName: Option[String] = None
+    def webTitle: String = ""
+    def webUrl: String = ""
+    def apiUrl: String = ""
+    def references: Seq[Reference] = Nil
+    def description: Option[String] = None
+    def bio: Option[String] = None
+    def bylineImageUrl: Option[String] = None
+    def bylineLargeImageUrl: Option[String] = None
+    def podcast: Option[Podcast] = None
+    def firstName: Option[String] = None
+    def lastName: Option[String] = None
+    def emailAddress: Option[String] = None
+    def twitterHandle: Option[String] = None
+    def paidContentType: Option[String] = None
+    def paidContentCampaignColour: Option[String] = None
+    def rcsId: Option[String] = None
+    def r2ContributorId: Option[String] = None
+  }
+
+  case class StubItem(id: String, publicationDateText: Option[String], section: Option[StubSection], tags: Seq[StubTag])
+    extends Content {
+    def `type`: ContentType = ContentType.Article
+    def sectionId: Option[String] = None
+    def sectionName: Option[String] = None
+    def webPublicationDate: Option[CapiDateTime] = publicationDateText.map(dateTextToCapiDateTime)
+    def webTitle: String = ""
+    def webUrl: String = ""
+    def apiUrl: String = ""
+    def fields: Option[ContentFields] = None
+    def elements: Option[Seq[Element]] = None
+    def references: Seq[Reference] = Nil
+    def isExpired: Option[Boolean] = None
+    def blocks: Option[Blocks] = None
+    def rights: Option[Rights] = None
+    def crossword: Option[Crossword] = None
+    def atoms: Option[Atoms] = None
+    def stats: Option[ContentStats] = None
+    def debug: Option[Debug] = None
+    def isGone: Option[Boolean] = None
+    def isHosted: Boolean = false
+  }
+}

--- a/src/test/scala/com/gu/commercial/branding/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/branding/TestModel.scala
@@ -49,6 +49,56 @@ object TestModel {
     def editions: Seq[Edition] = Nil
   }
 
+  case class StubFields(isInappropriateForSponsorshipText: Option[String]) extends ContentFields {
+    def isInappropriateForSponsorship: Option[Boolean] = isInappropriateForSponsorshipText.map(_.toBoolean)
+    def headline: Option[String] = None
+    def standfirst: Option[String] = None
+    def trailText: Option[String] = None
+    def byline: Option[String] = None
+    def main: Option[String] = None
+    def body: Option[String] = None
+    def newspaperPageNumber: Option[Int] = None
+    def starRating: Option[Int] = None
+    def contributorBio: Option[String] = None
+    def membershipAccess: Option[MembershipTier] = None
+    def wordcount: Option[Int] = None
+    def commentCloseDate: Option[CapiDateTime] = None
+    def commentable: Option[Boolean] = None
+    def creationDate: Option[CapiDateTime] = None
+    def displayHint: Option[String] = None
+    def firstPublicationDate: Option[CapiDateTime] = None
+    def hasStoryPackage: Option[Boolean] = None
+    def internalComposerCode: Option[String] = None
+    def internalOctopusCode: Option[String] = None
+    def internalPageCode: Option[Int] = None
+    def internalStoryPackageCode: Option[Int] = None
+    def isPremoderated: Option[Boolean] = None
+    def lastModified: Option[CapiDateTime] = None
+    def liveBloggingNow: Option[Boolean] = None
+    def newspaperEditionDate: Option[CapiDateTime] = None
+    def productionOffice: Option[Office] = None
+    def publication: Option[String] = None
+    def scheduledPublicationDate: Option[CapiDateTime] = None
+    def secureThumbnail: Option[String] = None
+    def shortUrl: Option[String] = None
+    def shouldHideAdverts: Option[Boolean] = None
+    def showInRelatedContent: Option[Boolean] = None
+    def thumbnail: Option[String] = None
+    def legallySensitive: Option[Boolean] = None
+    def allowUgc: Option[Boolean] = None
+    def sensitive: Option[Boolean] = None
+    def lang: Option[String] = None
+    def internalRevision: Option[Int] = None
+    def internalContentCode: Option[Int] = None
+    def isLive: Option[Boolean] = None
+    def internalShortId: Option[String] = None
+    def shortSocialShareText: Option[String] = None
+    def socialShareText: Option[String] = None
+    def bodyText: Option[String] = None
+    def charCount: Option[Int] = None
+    def internalVideoCode: Option[String] = None
+  }
+
   case class StubTag(id: String, activeSponsorships: Option[Seq[TestSponsorship]]) extends Tag {
     def `type`: TagType = TagType.Keyword
     def sectionId: Option[String] = None
@@ -72,8 +122,13 @@ object TestModel {
     def r2ContributorId: Option[String] = None
   }
 
-  case class StubItem(id: String, publicationDateText: Option[String], section: Option[StubSection], tags: Seq[StubTag])
-    extends Content {
+  case class StubItem(
+    id: String,
+    publicationDateText: Option[String],
+    section: Option[StubSection],
+    fields: Option[StubFields],
+    tags: Seq[StubTag]
+  ) extends Content {
     def `type`: ContentType = ContentType.Article
     def sectionId: Option[String] = None
     def sectionName: Option[String] = None
@@ -81,7 +136,6 @@ object TestModel {
     def webTitle: String = ""
     def webUrl: String = ""
     def apiUrl: String = ""
-    def fields: Option[ContentFields] = None
     def elements: Option[Seq[Element]] = None
     def references: Seq[Reference] = Nil
     def isExpired: Option[Boolean] = None

--- a/src/test/scala/com/gu/commercial/branding/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/branding/TestModel.scala
@@ -22,6 +22,8 @@ object TestModel {
     def publishedSince: Option[CapiDateTime] = publishedSinceText.map(dateTextToCapiDateTime)
   }
 
+  case class TestLogoDimensions(width: Int, height: Int) extends SponsorshipLogoDimensions
+
   case class TestSponsorship(
     sponsorshipTypeName: String,
     sponsorName: String,
@@ -29,9 +31,9 @@ object TestModel {
     sponsorLink: String,
     targeting: Option[TestSponsorshipTargeting],
     aboutLink: Option[String],
-    sponsorLogoDimensions: Option[SponsorshipLogoDimensions],
+    sponsorLogoDimensions: Option[TestLogoDimensions],
     highContrastSponsorLogo: Option[String],
-    highContrastSponsorLogoDimensions: Option[SponsorshipLogoDimensions]
+    highContrastSponsorLogoDimensions: Option[TestLogoDimensions]
   ) extends Sponsorship {
     def sponsorshipType: SponsorshipType = sponsorshipTypeName match {
       case "sponsored" => SponsorshipType.Sponsored


### PR DESCRIPTION
This provides the minimal functionality for branding.
It finds the branding for a single content item.

From this we can derive the branding for a set of content items, which will follow in a separate PR.

Haven't set up config to release a jar yet.
