### PR TITLE
Use config, as well as content, to find branding of a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This codebase is going to hold the business logic for the display of commercial components, so that it can be shared across all Guardian platforms: web and app.
 
-## Initial assumptions
+## Assumptions
 0. It will be included in all frontend deployments that show commercial components
 0. It will be included in mapi deployments 
 0. It won't make any calls to external services
-0. Its only dependency is the capi model
+0. Its only dependencies are the capi model and the facia model
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ scalaVersion := "2.11.8"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % "11.0",
+  "com.gu" %% "fapi-client" % "2.0.9",
   "org.scalatest" %% "scalatest" % "3.0.1" % Test,
   "net.liftweb" %% "lift-json" % "3.0.1" % Test
 )

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -3,6 +3,8 @@ package com.gu.commercial.branding
 import com.gu.commercial.branding.BrandingFinder.findBranding
 import com.gu.commercial.branding.TestModel.{StubItem, StubSection}
 import com.gu.contentapi.client.model.v1.{Content, Section}
+import com.gu.facia.api.models.CollectionConfig
+import com.gu.facia.client.models.Branded
 import net.liftweb.json
 import net.liftweb.json.JsonAST.{JField, JValue}
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
@@ -39,6 +41,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
   private def getInappropriateItem = getContentItem("InappropriateContent.json")
 
   private def getBrandedSection = getSection("BrandedSection.json")
+
+  private val brandedContainerConfig = CollectionConfig.empty.copy(metadata = Some(List(Branded)))
 
   "findBranding: item" should "give branding of tag for content with a single branded tag" in {
     val item = getTagBrandedItem
@@ -164,7 +168,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       getTagBrandedItem,
       getMultipleTagBrandedItem
     )
-    val branding = findBranding(items, edition = "uk")
+    val branding = findBranding(brandedContainerConfig, items, edition = "uk")
     branding.value should be(Branding(
       brandingType = Sponsored,
       sponsor = "Fairtrade Foundation",
@@ -183,12 +187,21 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       getTagBrandedItem,
       getSectionBrandedItem
     )
-    val branding = findBranding(items, edition = "uk")
+    val branding = findBranding(brandedContainerConfig, items, edition = "uk")
     branding should be(None)
   }
 
   it should "give no branding for an empty set" in {
-    val branding = findBranding(Set.empty, edition = "uk")
+    val branding = findBranding(brandedContainerConfig, content = Set.empty, edition = "uk")
+    branding should be(None)
+  }
+
+  it should "give no branding for a container without branded config" in {
+    val items = Set(
+      getTagBrandedItem,
+      getMultipleTagBrandedItem
+    )
+    val branding = findBranding(CollectionConfig.empty, items, edition = "uk")
     branding should be(None)
   }
 


### PR DESCRIPTION
Use the 'branded' flag that's set in the fronts tool as part of the branding logic.
This is just for completeness, to keep all the logic in one place.

It does mean adding a dependency on the facia client to the library.  But I think it might be useful to understand where the flag comes from.