### PR TITLE
Support paid multi-sponsor container branding

### DIFF
--- a/src/main/scala/com/gu/commercial/branding/Branding.scala
+++ b/src/main/scala/com/gu/commercial/branding/Branding.scala
@@ -1,6 +1,8 @@
 package com.gu.commercial.branding
 
-import com.gu.contentapi.client.model.v1.{Sponsorship, SponsorshipLogoDimensions, SponsorshipType}
+import com.gu.contentapi.client.model.v1.Sponsorship
+
+sealed trait ContainerBranding
 
 case class Branding(
   brandingType: BrandingType,
@@ -8,7 +10,7 @@ case class Branding(
   logo: Logo,
   logoForDarkBackground: Option[Logo],
   aboutThisLink: Option[String]
-)
+) extends ContainerBranding
 
 object Branding {
 
@@ -37,33 +39,4 @@ object Branding {
   }
 }
 
-case class Logo(
-  src: String,
-  dimensions: Option[Dimensions],
-  link: String,
-  label: String
-)
-
-object Logo {
-
-  def make(
-    title: String,
-    sponsorshipType: SponsorshipType,
-    src: String,
-    dimensions: Option[SponsorshipLogoDimensions],
-    link: String
-  ): Logo = {
-    Logo(
-      src = src,
-      dimensions = dimensions.map(d => Dimensions(d.width, d.height)),
-      link,
-      label = sponsorshipType match {
-        case SponsorshipType.PaidContent => "Paid for by"
-        case SponsorshipType.Foundation => s"$title is supported by"
-        case _ => "Supported by"
-      }
-    )
-  }
-}
-
-case class Dimensions(width: Int, height: Int)
+case object PaidMultiSponsorBranding extends ContainerBranding

--- a/src/main/scala/com/gu/commercial/branding/Logo.scala
+++ b/src/main/scala/com/gu/commercial/branding/Logo.scala
@@ -1,0 +1,34 @@
+package com.gu.commercial.branding
+
+import com.gu.contentapi.client.model.v1.{SponsorshipLogoDimensions, SponsorshipType}
+
+case class Logo(
+  src: String,
+  dimensions: Option[Dimensions],
+  link: String,
+  label: String
+)
+
+object Logo {
+
+  def make(
+    title: String,
+    sponsorshipType: SponsorshipType,
+    src: String,
+    dimensions: Option[SponsorshipLogoDimensions],
+    link: String
+  ): Logo = {
+    Logo(
+      src = src,
+      dimensions = dimensions.map(d => Dimensions(d.width, d.height)),
+      link,
+      label = sponsorshipType match {
+        case SponsorshipType.PaidContent => "Paid for by"
+        case SponsorshipType.Foundation => s"$title is supported by"
+        case _ => "Supported by"
+      }
+    )
+  }
+}
+
+case class Dimensions(width: Int, height: Int)

--- a/src/test/resources/PaidContent.json
+++ b/src/test/resources/PaidContent.json
@@ -1,0 +1,96 @@
+{
+  "id": "marriott-travels/2016/nov/15/seven-surprising-facts-about-the-worlds-largest-hotel-group",
+  "type": "article",
+  "sectionId": "marriott-travels",
+  "sectionName": "Marriott Travels",
+  "webPublicationDate": "2016-11-15T17:29:54Z",
+  "webTitle": "Seven surprising facts about the world's largest hotel group",
+  "webUrl": "https://www.theguardian.com/marriott-travels/2016/nov/15/seven-surprising-facts-about-the-worlds-largest-hotel-group",
+  "apiUrl": "https://content.guardianapis.com/marriott-travels/2016/nov/15/seven-surprising-facts-about-the-worlds-largest-hotel-group",
+  "fields": {
+    "isInappropriateForSponsorship": "false"
+  },
+  "tags": [
+    {
+      "id": "marriott-travels/marriott-travels",
+      "type": "paid-content",
+      "webTitle": "Marriott Travels",
+      "webUrl": "https://www.theguardian.com/marriott-travels/marriott-travels",
+      "apiUrl": "https://content.guardianapis.com/marriott-travels/marriott-travels",
+      "references": [
+
+      ],
+      "activeSponsorships": [
+        {
+          "sponsorshipType": "paid-content",
+          "sponsorName": "Marriott Hotels",
+          "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/09/Nov/2016/9d4910cd-55ed-42aa-92bc-5a4fce76dc53-Marriott_logo_2.png",
+          "sponsorLink": "http://www.marriott.co.uk/rewards/rewards-program.mi",
+          "sponsorLogoDimensions": {
+            "width": 140,
+            "height": 90
+          }
+        }
+      ],
+      "paidContentType": "Topic"
+    },
+    {
+      "id": "type/article",
+      "type": "type",
+      "webTitle": "Article",
+      "webUrl": "https://www.theguardian.com/articles",
+      "apiUrl": "https://content.guardianapis.com/type/article",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "tone/advertisement-features",
+      "type": "tone",
+      "webTitle": "Advertisement features",
+      "webUrl": "https://www.theguardian.com/tone/advertisement-features",
+      "apiUrl": "https://content.guardianapis.com/tone/advertisement-features",
+      "references": [
+
+      ]
+    },
+    {
+      "id": "tracking/commissioningdesk/uk-labs",
+      "type": "tracking",
+      "webTitle": "UK Labs",
+      "webUrl": "https://www.theguardian.com/tracking/commissioningdesk/uk-labs",
+      "apiUrl": "https://content.guardianapis.com/tracking/commissioningdesk/uk-labs",
+      "references": [
+
+      ]
+    }
+  ],
+  "section": {
+    "id": "marriott-travels",
+    "webTitle": "Marriott Travels",
+    "webUrl": "https://www.theguardian.com/marriott-travels",
+    "apiUrl": "https://content.guardianapis.com/marriott-travels",
+    "editions": [
+      {
+        "id": "marriott-travels",
+        "webTitle": "Marriott Travels",
+        "webUrl": "https://www.theguardian.com/marriott-travels",
+        "apiUrl": "https://content.guardianapis.com/marriott-travels",
+        "code": "default"
+      }
+    ],
+    "activeSponsorships": [
+      {
+        "sponsorshipType": "paid-content",
+        "sponsorName": "Marriott Hotels",
+        "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/09/Nov/2016/9d4910cd-55ed-42aa-92bc-5a4fce76dc53-Marriott_logo_2.png",
+        "sponsorLink": "http://www.marriott.co.uk/rewards/rewards-program.mi",
+        "sponsorLogoDimensions": {
+          "width": 140,
+          "height": 90
+        }
+      }
+    ]
+  },
+  "isHosted": false
+}

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -44,6 +44,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
   private def getBeforeDateTargetedTagBrandedItem = getContentItem("BeforeDateTargetedTagBrandedContent.json")
   private def getAfterDateTargetedTagBrandedItem = getContentItem("AfterDateTargetedTagBrandedContent.json")
   private def getInappropriateItem = getContentItem("InappropriateContent.json")
+  private def getPaidItem = getContentItem("PaidContent.json")
 
   private def getBrandedSection = getSection("BrandedSection.json")
 
@@ -217,6 +218,15 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
     )
     val branding = findBranding(CollectionConfig.empty, items, edition = "uk")
     branding should be(None)
+  }
+
+  it should "give paid container branding for a multi-sponsor paid container" in {
+    val items = Set(
+      getAfterDateTargetedTagBrandedItem,
+      getPaidItem
+    )
+    val branding = findBranding(brandedContainerConfig, items, edition = "uk")
+    branding.value should be(PaidMultiSponsorBranding)
   }
 
   "findBranding: section" should "give section branding for a branded section result" in {


### PR DESCRIPTION
The signature of [findBranding](https://github.com/guardian/commercial-shared/compare/kc-paid-container?expand=1#diff-c8ded0d66f9b0f9e4d1199768694d2f9R52) has now changed to give an optional `ContainerBranding`.
This is to support the case where the container should appear as a paid container without showing a logo.

/cc @guardian/mobile-server-side-staff 