### PR TITLE
Add campaign colour to branding model

### DIFF
--- a/src/main/scala/com/gu/commercial/branding/Branding.scala
+++ b/src/main/scala/com/gu/commercial/branding/Branding.scala
@@ -10,7 +10,7 @@ case class Branding(
   logo: Logo,
   logoForDarkBackground: Option[Logo],
   aboutThisLink: Option[String],
-  campaignColour: Option[String]
+  hostedCampaignColour: Option[String]
 ) extends ContainerBranding {
   def isPaid: Boolean = brandingType == PaidContent
   def isSponsored: Boolean = brandingType == Sponsored
@@ -40,7 +40,7 @@ object Branding {
         )
       },
       aboutThisLink = sponsorship.aboutLink,
-      campaignColour = campaignColour
+      hostedCampaignColour = campaignColour
     )
   }
 }

--- a/src/main/scala/com/gu/commercial/branding/Branding.scala
+++ b/src/main/scala/com/gu/commercial/branding/Branding.scala
@@ -9,7 +9,8 @@ case class Branding(
   sponsorName: String,
   logo: Logo,
   logoForDarkBackground: Option[Logo],
-  aboutThisLink: Option[String]
+  aboutThisLink: Option[String],
+  campaignColour: Option[String]
 ) extends ContainerBranding {
   def isPaid: Boolean = brandingType == PaidContent
   def isSponsored: Boolean = brandingType == Sponsored
@@ -18,7 +19,7 @@ case class Branding(
 
 object Branding {
 
-  def fromSponsorship(webTitle: String, sponsorship: Sponsorship): Branding = {
+  def fromSponsorship(webTitle: String, campaignColour: Option[String], sponsorship: Sponsorship): Branding = {
     Branding(
       brandingType = BrandingType.fromSponsorshipType(sponsorship.sponsorshipType),
       sponsorName = sponsorship.sponsorName,
@@ -38,7 +39,8 @@ object Branding {
           link = sponsorship.sponsorLink
         )
       },
-      aboutThisLink = sponsorship.aboutLink
+      aboutThisLink = sponsorship.aboutLink,
+      campaignColour = campaignColour
     )
   }
 }

--- a/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
+++ b/src/main/scala/com/gu/commercial/branding/BrandingFinder.scala
@@ -71,15 +71,12 @@ object BrandingFinder {
     findBranding(tag, edition, publishedDate = None)
 
   private def findBranding(section: Section, edition: String, publishedDate: Option[CapiDateTime]): Option[Branding] =
-    for {
-      sponsorship <- findSponsorshipFromSection(section, edition, publishedDate)
-    } yield Branding.fromSponsorship(section.webTitle, sponsorship)
+    for (sponsorship <- findSponsorshipFromSection(section, edition, publishedDate))
+      yield Branding.fromSponsorship(section.webTitle, campaignColour = None, sponsorship)
 
-  private def findBranding(tag: Tag, edition: String, publishedDate: Option[CapiDateTime]): Option[Branding] = {
-    for {
-      sponsorship <- findSponsorshipFromTag(tag, edition, publishedDate)
-    } yield Branding.fromSponsorship(tag.webTitle, sponsorship)
-  }
+  private def findBranding(tag: Tag, edition: String, publishedDate: Option[CapiDateTime]): Option[Branding] =
+    for (sponsorship <- findSponsorshipFromTag(tag, edition, publishedDate))
+      yield Branding.fromSponsorship(tag.webTitle, campaignColour = tag.paidContentCampaignColour, sponsorship)
 }
 
 object SponsorshipHelper {

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -66,7 +66,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       ),
       logoForDarkBackground = None,
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -84,7 +84,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       ),
       logoForDarkBackground = None,
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -107,7 +107,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Cities is supported by"
       )),
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -125,7 +125,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       ),
       logoForDarkBackground = None,
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -143,7 +143,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       ),
       logoForDarkBackground = None,
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -167,7 +167,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       ),
       logoForDarkBackground = None,
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -200,7 +200,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       ),
       logoForDarkBackground = None,
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -255,7 +255,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Cities is supported by"
       )),
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 
@@ -273,7 +273,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
       ),
       logoForDarkBackground = None,
       aboutThisLink = None,
-      campaignColour = None
+      hostedCampaignColour = None
     ))
   }
 }

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -65,7 +65,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -82,7 +83,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -104,7 +106,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         link = "http://www.100resilientcities.org/",
         label = "Cities is supported by"
       )),
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -121,7 +124,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -138,7 +142,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -161,7 +166,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Paid for by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -193,7 +199,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -247,7 +254,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         link = "http://www.100resilientcities.org/",
         label = "Cities is supported by"
       )),
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 
@@ -264,7 +272,8 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None
+      aboutThisLink = None,
+      campaignColour = None
     ))
   }
 }

--- a/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
@@ -14,7 +14,8 @@ class BrandingSpec extends FlatSpec with Matchers with OptionValues {
       label = "label"
     ),
     logoForDarkBackground = None,
-    aboutThisLink = None
+    aboutThisLink = None,
+    campaignColour = None
   )
 
   "isPaid" should "be true for paid content" in {

--- a/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
@@ -15,7 +15,7 @@ class BrandingSpec extends FlatSpec with Matchers with OptionValues {
     ),
     logoForDarkBackground = None,
     aboutThisLink = None,
-    campaignColour = None
+    hostedCampaignColour = None
   )
 
   "isPaid" should "be true for paid content" in {


### PR DESCRIPTION
We should never need to repeat the logic to find the relevant `sponsorship` block from a capi result.

The only property I can find that would come from the context of a `sponsorship` block is the `paidContentCampaignColour`.  So I've added that to the branding model, for completeness.

/cc @guardian/mobile-server-side-staff 