### PR TITLE
Add surge level to page-level ad targeting

### DIFF
--- a/src/main/scala/com/gu/commercial/display/AdCall.scala
+++ b/src/main/scala/com/gu/commercial/display/AdCall.scala
@@ -4,9 +4,14 @@ import com.gu.commercial.branding.{Branding, BrandingFinder}
 import com.gu.contentapi.client.model.v1.TagType._
 import com.gu.contentapi.client.model.v1.{Content, Section, Tag}
 
-class AdCall(platform: String) {
+class AdCall(platform: String, surgeLookupService: SurgeLookupService) {
 
   private val ukNewsKeywordId = "uk/uk"
+
+  private def csv[A](values: Seq[A]) = values.mkString(",")
+
+  private def toItemId(path: String) = path.stripPrefix("/")
+  private def toPath(itemId: String) = s"/$itemId"
 
   private def targetValue(id: String): String = {
     def takeFinalSegment(s: String) = s.takeRight(s.length - s.lastIndexOf('/') - 1)
@@ -17,6 +22,8 @@ class AdCall(platform: String) {
   private def targetValue(tag: Tag): String = targetValue(tag.id)
 
   private def toBrandingType(b: Option[Branding]) = b.map(_.brandingType.name.take(1)) getOrElse ""
+
+  private def surgeLevels(itemId: String) = csv(Surge.bucket(surgeLookupService.pageViewsPerMinute(itemId)))
 
   /**
     * Content page.
@@ -29,8 +36,6 @@ class AdCall(platform: String) {
 
     def tagValues(p: Tag => Boolean) = for (tag <- item.tags if p(tag)) yield targetValue(tag)
 
-    def csv(values: Seq[String]) = values.mkString(",")
-
     val authors = tagValues(_.`type` == Contributor)
     val blogs = tagValues(_.`type` == Blog)
     val brandingType = toBrandingType(BrandingFinder.findBranding(item, edition))
@@ -39,7 +44,6 @@ class AdCall(platform: String) {
     val keywords = tagValues(_.`type` == Keyword)
     val paidSeries = tagValues(_.paidContentType.contains("Series"))
     val paidTopics = tagValues(_.paidContentType.contains("Topic"))
-    val path = s"/${item.id}"
     val series = tagValues(_.`type` == Series)
     val tones = tagValues(_.`type` == Tone)
 
@@ -52,9 +56,10 @@ class AdCall(platform: String) {
         EditionKey -> edition.toLowerCase,
         KeywordKey -> csv(keywords ++ paidTopics),
         ObserverKey -> isObserver,
-        PathKey -> path,
+        PathKey -> toPath(item.id),
         PlatformKey -> platform,
         SeriesKey -> csv(series ++ paidSeries),
+        SurgeLevelKey -> surgeLevels(item.id),
         ToneKey -> csv(tones)
       ) if value.nonEmpty
     } yield (name, value)
@@ -69,8 +74,9 @@ class AdCall(platform: String) {
       ContentTypeKey -> "section",
       EditionKey -> edition.toLowerCase,
       KeywordKey -> targetValue(section.id),
-      PathKey -> s"/${ section.id }",
-      PlatformKey -> platform
+      PathKey -> toPath(section.id),
+      PlatformKey -> platform,
+      SurgeLevelKey -> surgeLevels(section.id)
       ) if value.nonEmpty
     } yield (name, value)
 
@@ -96,8 +102,9 @@ class AdCall(platform: String) {
         BrandingKey -> toBrandingType(BrandingFinder.findBranding(tag, edition)),
         ContentTypeKey -> "tag",
         EditionKey -> edition.toLowerCase,
-        PathKey -> s"/${ tag.id }",
-        PlatformKey -> platform
+        PathKey -> toPath(tag.id),
+        PlatformKey -> platform,
+        SurgeLevelKey -> surgeLevels(tag.id)
       ) if value.nonEmpty
     } yield (key, value)
     tagParam map (p => params + p) getOrElse params
@@ -110,9 +117,10 @@ class AdCall(platform: String) {
     (name, value) <- Map[AdCallParamKey, String](
       ContentTypeKey -> "network-front",
       EditionKey -> edition.toLowerCase,
-      KeywordKey -> networkFrontPath.stripPrefix("/"),
+      KeywordKey -> toItemId(networkFrontPath),
       PathKey -> networkFrontPath,
-      PlatformKey -> platform
+      PlatformKey -> platform,
+      SurgeLevelKey -> surgeLevels(toItemId(networkFrontPath))
     ) if value.nonEmpty
   } yield (name, value)
 }

--- a/src/main/scala/com/gu/commercial/display/AdCall.scala
+++ b/src/main/scala/com/gu/commercial/display/AdCall.scala
@@ -1,6 +1,7 @@
 package com.gu.commercial.display
 
 import com.gu.commercial.branding.{Branding, BrandingFinder}
+import com.gu.commercial.display.Surge.bucket
 import com.gu.contentapi.client.model.v1.TagType._
 import com.gu.contentapi.client.model.v1.{Content, Section, Tag}
 
@@ -23,7 +24,7 @@ class AdCall(platform: String, surgeLookupService: SurgeLookupService) {
 
   private def toBrandingType(b: Option[Branding]) = b.map(_.brandingType.name.take(1)) getOrElse ""
 
-  private def surgeLevels(itemId: String) = csv(Surge.bucket(surgeLookupService.pageViewsPerMinute(itemId)))
+  private def surgeLevels(itemId: String) = csv(bucket(surgeLookupService.pageViewsPerMinute(itemId)))
 
   /**
     * Content page.

--- a/src/main/scala/com/gu/commercial/display/AdCallParamKey.scala
+++ b/src/main/scala/com/gu/commercial/display/AdCallParamKey.scala
@@ -14,4 +14,5 @@ case object ObserverKey extends AdCallParamKey {val name = "ob" }
 case object PathKey extends AdCallParamKey {val name = "url" }
 case object PlatformKey extends AdCallParamKey {val name = "p" }
 case object SeriesKey extends AdCallParamKey {val name = "se" }
+case object SurgeLevelKey extends AdCallParamKey {val name = "su" }
 case object ToneKey extends AdCallParamKey {val name = "tn" }

--- a/src/main/scala/com/gu/commercial/display/Surge.scala
+++ b/src/main/scala/com/gu/commercial/display/Surge.scala
@@ -1,0 +1,19 @@
+package com.gu.commercial.display
+
+object Surge {
+
+  def bucket(pvsPerMin:Option[Int]):Seq[Int] = {
+
+    val maxLevel = pvsPerMin match {
+      case Some(pv) if pv >= 400 => 1
+      case Some(pv) if pv >= 300 => 2
+      case Some(pv) if pv >= 200 => 3
+      case Some(pv) if pv >= 100 => 4
+      case Some(pv) if pv >= 50 => 5
+      case _ => 0
+      }
+
+    if (maxLevel == 0) Seq(0)
+    else Seq.range(maxLevel, 6)
+  }
+}

--- a/src/main/scala/com/gu/commercial/display/SurgeLookupService.scala
+++ b/src/main/scala/com/gu/commercial/display/SurgeLookupService.scala
@@ -1,0 +1,12 @@
+package com.gu.commercial.display
+
+/**
+  * This is intended to be implemented by an Ophan API lookup.
+  */
+trait SurgeLookupService {
+
+  /**
+    * This is intended to be implemented by the Ophan 'surging' service.
+    */
+  def pageViewsPerMinute(pageId: String): Option[Int]
+}

--- a/src/main/scala/com/gu/commercial/display/SurgeLookupService.scala
+++ b/src/main/scala/com/gu/commercial/display/SurgeLookupService.scala
@@ -1,12 +1,12 @@
 package com.gu.commercial.display
 
 /**
-  * This is intended to be implemented by an Ophan API lookup.
+  * This is intended to be implemented by Ophan API lookups.
   */
 trait SurgeLookupService {
 
   /**
-    * This is intended to be implemented by the Ophan 'surging' service.
+    * This is intended to be implemented by caching results from the Ophan 'surging' service.
     */
   def pageViewsPerMinute(pageId: String): Option[Int]
 }

--- a/src/test/scala/com/gu/commercial/display/AdCallSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/AdCallSpec.scala
@@ -5,7 +5,16 @@ import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
 class AdCallSpec extends FlatSpec with Matchers with OptionValues {
 
-  private val adCall = new AdCall(platform = "ng")
+  private val surgeLookup = new SurgeLookupService {
+    def pageViewsPerMinute(pageId: String): Option[Int] = pageId match {
+      case "sustainable-business/series/spotlight-on-commodities" => Some(1534)
+      case "lifeandstyle/turkey" => Some(296)
+      case "books/2016/jan/03/murder-for-christmas-mystery-of-author-francis-duncan" => Some(76)
+      case _ => None
+    }
+  }
+
+  private val adCall = new AdCall(platform = "ng", surgeLookup)
 
   private def stringifyKeys(params: Map[AdCallParamKey, String]): Map[String, String] =
     params.map { case (k, v) => k.name -> v }
@@ -21,6 +30,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "k" -> "sustainable-business,brazil,americas,world,coffee,global-development,fair-trade,environment",
       "p" -> "ng",
       "se" -> "spotlight-on-commodities",
+      "su" -> "0",
       "tn" -> "news",
       "url" ->
       "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
@@ -36,6 +46,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "edition" -> "uk",
       "k" -> "robots,museums,culture,technology,science,london,uk/uk",
       "p" -> "ng",
+      "su" -> "0",
       "tn" -> "news",
       "url" -> "/technology/video/2017/feb/07/science-museum-robots-exhibition-backstage"
     )
@@ -51,6 +62,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "k" -> "crime,books,culture,fiction,uk/uk",
       "ob" -> "t",
       "p" -> "ng",
+      "su" -> "5",
       "tn" -> "news",
       "url" -> "/books/2016/jan/03/murder-for-christmas-mystery-of-author-francis-duncan"
     )
@@ -65,6 +77,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "edition" -> "uk",
       "k" -> "cities",
       "p" -> "ng",
+      "su" -> "0",
       "url" -> "/cities"
     )
   }
@@ -77,6 +90,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "edition" -> "uk",
       "k" -> "culture",
       "p" -> "ng",
+      "su" -> "0",
       "url" -> "/uk/culture"
     )
   }
@@ -90,6 +104,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "edition" -> "uk",
       "p" -> "ng",
       "se" -> "spotlight-on-commodities",
+      "su" -> "1,2,3,4,5",
       "url" -> "/sustainable-business/series/spotlight-on-commodities"
     )
   }
@@ -102,6 +117,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "edition" -> "uk",
       "p" -> "ng",
       "se" -> "new-view-series",
+      "su" -> "0",
       "url" -> "/film/series/new-view-series"
     )
   }
@@ -114,6 +130,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "edition" -> "us",
       "k" -> "turkey",
       "p" -> "ng",
+      "su" -> "3,4,5",
       "url" -> "/lifeandstyle/turkey"
     )
   }
@@ -125,6 +142,7 @@ class AdCallSpec extends FlatSpec with Matchers with OptionValues {
       "edition" -> "au",
       "k" -> "us",
       "p" -> "ng",
+      "su" -> "0",
       "url" -> "/us"
     )
   }

--- a/src/test/scala/com/gu/commercial/display/SurgeSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/SurgeSpec.scala
@@ -1,0 +1,17 @@
+package com.gu.commercial.display
+
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+class SurgeSpec extends FlatSpec with Matchers with OptionValues {
+
+  "bucket" should "put page views per minute into a range of bucket values" in {
+    Surge.bucket(Some(500)) shouldBe Seq(1, 2, 3, 4, 5)
+    Surge.bucket(Some(401)) shouldBe Seq(1, 2, 3, 4, 5)
+    Surge.bucket(Some(301)) shouldBe Seq(2, 3, 4, 5)
+    Surge.bucket(Some(201)) shouldBe Seq(3, 4, 5)
+    Surge.bucket(Some(101)) shouldBe Seq(4, 5)
+    Surge.bucket(Some(99)) shouldBe Seq(5)
+    Surge.bucket(Some(49)) shouldBe Seq(0)
+    Surge.bucket(None) shouldBe Seq(0)
+  }
+}


### PR DESCRIPTION
This adds a `su` parameter to ad targeting, to target the surging level.
A page is considered to be surging when its recent views per minute goes above a certain threshold.
The value is bucketed into a range of parameter values between 0 and 5.

Access to the Ophan API is required in the context where this is used.  See https://github.com/guardian/commercial-shared/blob/kc-surge/src/main/scala/com/gu/commercial/display/SurgeLookupService.scala

/cc @guardian/mobile-server-side-staff 