### PR TITLE
Branding should always have an 'about this' link

### DIFF
--- a/src/main/scala/com/gu/commercial/branding/Branding.scala
+++ b/src/main/scala/com/gu/commercial/branding/Branding.scala
@@ -9,7 +9,7 @@ case class Branding(
   sponsorName: String,
   logo: Logo,
   logoForDarkBackground: Option[Logo],
-  aboutThisLink: Option[String],
+  aboutThisLink: String,
   hostedCampaignColour: Option[String]
 ) extends ContainerBranding {
   def isPaid: Boolean = brandingType == PaidContent
@@ -18,6 +18,8 @@ case class Branding(
 }
 
 object Branding {
+
+  val defaultAboutThisLink = "https://www.theguardian.com/info/2016/jan/25/content-funding"
 
   def fromSponsorship(webTitle: String, campaignColour: Option[String], sponsorship: Sponsorship): Branding = {
     Branding(
@@ -39,7 +41,7 @@ object Branding {
           link = sponsorship.sponsorLink
         )
       },
-      aboutThisLink = sponsorship.aboutLink,
+      aboutThisLink = sponsorship.aboutLink getOrElse defaultAboutThisLink,
       hostedCampaignColour = campaignColour
     )
   }

--- a/src/test/resources/BrandedTag.json
+++ b/src/test/resources/BrandedTag.json
@@ -11,7 +11,8 @@
       "sponsorshipType": "sponsored",
       "sponsorName": "Fairtrade Foundation",
       "sponsorLogo": "https://static.theguardian.com/commercial/sponsor/sustainable/series/spotlight-commodities/logo.png",
-      "sponsorLink": "http://www.fairtrade.org.uk/"
+      "sponsorLink": "http://www.fairtrade.org.uk/",
+      "aboutLink": "https://www.theguardian.com/uk"
     },
     {
       "sponsorshipType": "foundation",

--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -37,7 +37,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -55,7 +55,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -78,7 +78,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         link = "http://www.100resilientcities.org/",
         label = "Cities is supported by"
       )),
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -96,7 +96,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -114,7 +114,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -138,7 +138,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Paid for by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -171,7 +171,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -226,7 +226,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         link = "http://www.100resilientcities.org/",
         label = "Cities is supported by"
       )),
-      aboutThisLink = None,
+      aboutThisLink = Branding.defaultAboutThisLink,
       hostedCampaignColour = None
     ))
   }
@@ -244,7 +244,7 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
         label = "Supported by"
       ),
       logoForDarkBackground = None,
-      aboutThisLink = None,
+      aboutThisLink = "https://www.theguardian.com/uk",
       hostedCampaignColour = None
     ))
   }

--- a/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
@@ -14,7 +14,7 @@ class BrandingSpec extends FlatSpec with Matchers with OptionValues {
       label = "label"
     ),
     logoForDarkBackground = None,
-    aboutThisLink = None,
+    aboutThisLink = Branding.defaultAboutThisLink,
     hostedCampaignColour = None
   )
 


### PR DESCRIPTION
If it's not given in the tag manager we use the content funding page as a default value.