### PR TITLE
Clean ad targeting values

### DIFF
--- a/src/main/scala/com/gu/commercial/display/Cleaner.scala
+++ b/src/main/scala/com/gu/commercial/display/Cleaner.scala
@@ -1,0 +1,9 @@
+package com.gu.commercial.display
+
+object Cleaner {
+
+  val illegalChars = """"'=!+#*~;^()<>[]&"""
+
+  def cleanValue(v: String): String =
+    illegalChars.foldLeft(v.trim.toLowerCase) { case (acc, c) => acc.replaceAll(s"\\$c", "") }
+}

--- a/src/test/scala/com/gu/commercial/display/CleanerSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/CleanerSpec.scala
@@ -1,0 +1,90 @@
+package com.gu.commercial.display
+
+import com.gu.commercial.display.Cleaner.cleanValue
+import org.scalatest.{FlatSpec, Matchers}
+
+// enforces these rules: https://support.google.com/dfp_sb/answer/177381
+class CleanerSpec extends FlatSpec with Matchers {
+
+  private def testForIllegalCharacter(c: Char) = cleanValue(s"abc${ c }def") shouldBe "abcdef"
+
+  "A targeting value" should "only have lowercase characters because it's case-insensitive" in {
+    cleanValue("Val") shouldBe "val"
+  }
+
+  it should """not contain '"'""" in {
+    testForIllegalCharacter('"')
+  }
+
+  it should "not contain '''" in {
+    testForIllegalCharacter(''')
+  }
+
+  it should "not contain '='" in {
+    testForIllegalCharacter('=')
+  }
+
+  it should "not contain '!'" in {
+    testForIllegalCharacter('!')
+  }
+
+  it should "not contain '+'" in {
+    testForIllegalCharacter('+')
+  }
+
+  it should "not contain '#'" in {
+    testForIllegalCharacter('#')
+  }
+
+  it should "not contain '*'" in {
+    testForIllegalCharacter('*')
+  }
+
+  it should "not contain '~'" in {
+    testForIllegalCharacter('~')
+  }
+
+  it should "not contain ';'" in {
+    testForIllegalCharacter(';')
+  }
+
+  it should "not contain '^'" in {
+    testForIllegalCharacter('^')
+  }
+
+  it should "not contain '('" in {
+    testForIllegalCharacter('(')
+  }
+
+  it should "not contain ')'" in {
+    testForIllegalCharacter(')')
+  }
+
+  it should "not contain '<'" in {
+    testForIllegalCharacter('<')
+  }
+
+  it should "not contain '>'" in {
+    testForIllegalCharacter('>')
+  }
+
+  it should "not contain '['" in {
+    testForIllegalCharacter('[')
+  }
+
+  it should "not contain ']'" in {
+    testForIllegalCharacter(']')
+  }
+
+  it should "not contain '&'" in {
+    testForIllegalCharacter('&')
+  }
+
+  it should "be able to contain spaces" in {
+    cleanValue("a bc d ef") shouldBe "a bc d ef"
+  }
+
+  it should "not start with a space" in {
+    cleanValue(" abc") shouldBe "abc"
+  }
+}


### PR DESCRIPTION
This cleans ad targeting values before sending them to the ad server.  
It's inspired by the tests written by @DiegoVazquezNanini in https://github.com/guardian/mobile-apps-api/blob/master/common/test/models/MetadataSpec.scala
