### PR TITLE
Fix bug when unbranded card in container branding

### DIFF
--- a/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingFinderSpec.scala
@@ -185,6 +185,16 @@ class BrandingFinderSpec extends FlatSpec with Matchers with OptionValues {
     branding should be(None)
   }
 
+  it should "give no branding if any item in set has no branding" in {
+    val items = Set(
+      getTagBrandedItem,
+      getMultipleTagBrandedItem,
+      getInappropriateItem
+    )
+    val branding = findBranding(brandedContainerConfig, items, edition = "uk")
+    branding should be(None)
+  }
+
   it should "give no branding for an empty set" in {
     val branding = findBranding(brandedContainerConfig, content = Set.empty, edition = "uk")
     branding should be(None)


### PR DESCRIPTION
This fixes a regression bug.
When a container holds some unbranded content it shouldn't show any branding.
