### PR TITLE
Treat the inequality section as a special case

### DIFF
--- a/src/main/scala/com/gu/commercial/branding/Logo.scala
+++ b/src/main/scala/com/gu/commercial/branding/Logo.scala
@@ -11,6 +11,8 @@ case class Logo(
 
 object Logo {
 
+  val sensitiveTitles = Seq("inequality")
+
   def make(
     title: String,
     sponsorshipType: SponsorshipType,
@@ -24,6 +26,8 @@ object Logo {
       link,
       label = sponsorshipType match {
         case SponsorshipType.PaidContent => "Paid for by"
+        case SponsorshipType.Foundation if sensitiveTitles.contains(title) =>
+          s"The ${title.capitalize} Project is supported by"
         case SponsorshipType.Foundation => s"$title is supported by"
         case _ => "Supported by"
       }

--- a/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
@@ -1,0 +1,35 @@
+package com.gu.commercial.branding
+
+import com.gu.contentapi.client.model.v1.SponsorshipType
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+class LogoSpec extends FlatSpec with Matchers with OptionValues {
+
+  private def mkLogo(sponsorshipType: SponsorshipType, title: String = "") = Logo.make(
+    title = title,
+    sponsorshipType = sponsorshipType,
+    src = "src",
+    dimensions = None,
+    link = "link"
+  )
+
+  "make" should "generate the correct label for sponsored content" in {
+    val logo = mkLogo(SponsorshipType.Sponsored)
+    logo.label shouldBe "Supported by"
+  }
+
+  it should "generate the correct label for paid content" in {
+    val logo = mkLogo(SponsorshipType.PaidContent)
+    logo.label shouldBe "Paid for by"
+  }
+
+  it should "generate the correct label for foundation-funded content" in {
+    val logo = mkLogo(SponsorshipType.Foundation, title = "someTitle")
+    logo.label shouldBe "someTitle is supported by"
+  }
+
+  it should "generate the correct label for the special inequality foundation-funded section" in {
+    val logo = mkLogo(SponsorshipType.Foundation, title = "inequality")
+    logo.label shouldBe "The Inequality Project is supported by"
+  }
+}


### PR DESCRIPTION
This seems like a highly unusual case because the wording of the label looks bad for the sponsor. 
 
So I've made it a special hardcoded case.

Before:
![image](https://cloud.githubusercontent.com/assets/1722550/25237654/2d4bb134-25e3-11e7-8c24-9aa30ee1fa7a.png)

After:
_The Inequality Project is supported by_ ...
