### PR TITLE
Bump facia dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.11.11"
 
 libraryDependencies ++= Seq(
   "com.gu" % "content-api-models-scala" % "11.12",
-  "com.gu" %% "fapi-client" % "2.0.13",
+  "com.gu" %% "fapi-client" % "2.0.15",
   "org.scalatest" %% "scalatest" % "3.0.3" % Test,
   "net.liftweb" %% "lift-json" % "3.0.1" % Test
 )


### PR DESCRIPTION
It looks like there may be a clash between the facia client pulled in by commercial shared and the one that is a direct dependency of frontend/MAPI.  Bumping this version to the same as those so we can release a new special report tag.

@DiegoVazquezNanini @kelvin-chappell 