### PR TITLE
Change scope of dependencies to provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ licenses += ("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
 scalaVersion := "2.11.11"
 
 libraryDependencies ++= Seq(
-  "com.gu" % "content-api-models-scala" % "11.12",
-  "com.gu" %% "fapi-client" % "2.0.15",
+  "com.gu" % "content-api-models-scala" % "11.14" % Provided,
+  "com.gu" %% "fapi-client" % "2.0.15" % Provided,
   "org.scalatest" %% "scalatest" % "3.0.3" % Test,
   "net.liftweb" %% "lift-json" % "3.0.1" % Test
 )


### PR DESCRIPTION
Because we assume that they will be available in the deployment environment.
Any problems will hopefully become apparent at compile-time downstream.