### PR TITLE
Adds another special case for sponsorships and title cases the replacement

### DIFF
--- a/src/main/scala/com/gu/commercial/branding/Logo.scala
+++ b/src/main/scala/com/gu/commercial/branding/Logo.scala
@@ -11,7 +11,8 @@ case class Logo(
 
 object Logo {
 
-  val sensitiveTitles = Seq("Inequality")
+  val sensitiveTitles = Map("Inequality" -> "The Inequality Project",
+                            "America's unequal future" -> "This series")
 
   def make(
     title: String,
@@ -26,9 +27,8 @@ object Logo {
       link,
       label = sponsorshipType match {
         case SponsorshipType.PaidContent => "Paid for by"
-        case SponsorshipType.Foundation if sensitiveTitles.contains(title) =>
-          s"The ${title.capitalize} Project is supported by"
-        case SponsorshipType.Foundation => s"$title is supported by"
+        case SponsorshipType.Foundation =>
+          s"${sensitiveTitles.getOrElse(title, title)} is supported by"
         case _ => "Supported by"
       }
     )

--- a/src/main/scala/com/gu/commercial/branding/Logo.scala
+++ b/src/main/scala/com/gu/commercial/branding/Logo.scala
@@ -12,7 +12,7 @@ case class Logo(
 object Logo {
 
   val sensitiveTitles = Map("Inequality" -> "The Inequality Project",
-                            "America's unequal future" -> "This series")
+                            "Inequality and Opportunity in America" -> "This series")
 
   def make(
     title: String,

--- a/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
@@ -34,7 +34,7 @@ class LogoSpec extends FlatSpec with Matchers with OptionValues {
   }
 
   it should "generate the correct label for the special America's unequal future foundation-funded section" in {
-    val logo = mkLogo(SponsorshipType.Foundation, webTitle = "America's unequal future")
+    val logo = mkLogo(SponsorshipType.Foundation, webTitle = "Inequality and Opportunity in America")
     logo.label shouldBe "This series is supported by"
   }
 }

--- a/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
@@ -32,4 +32,9 @@ class LogoSpec extends FlatSpec with Matchers with OptionValues {
     val logo = mkLogo(SponsorshipType.Foundation, webTitle = "Inequality")
     logo.label shouldBe "The Inequality Project is supported by"
   }
+
+  it should "generate the correct label for the special America's unequal future foundation-funded section" in {
+    val logo = mkLogo(SponsorshipType.Foundation, webTitle = "America's unequal future")
+    logo.label shouldBe "This series is supported by"
+  }
 }


### PR DESCRIPTION
Fixes another awkward series sponsorship:

![image](https://cloud.githubusercontent.com/assets/1821099/26457362/c071583e-4167-11e7-937b-89ca88fd4785.png)

It also title cases the project name, which I think we probably want in this case:

_The America's Unequal Future project is sponsored by_

vs

_The America's unequal future project is sponsored by_

@kelvin-chappell 