### PR TITLE
Change AdCallParamValue to a sealed trait

### DIFF
--- a/src/main/scala/com/gu/commercial/display/AdCallParamValue.scala
+++ b/src/main/scala/com/gu/commercial/display/AdCallParamValue.scala
@@ -5,7 +5,7 @@ import com.gu.commercial.display.Surge.bucket
 import com.gu.contentapi.client.model.v1.TagType._
 import com.gu.contentapi.client.model.v1.{Content, Tag, TagType}
 
-trait AdCallParamValue {
+sealed trait AdCallParamValue {
   def nonEmpty: Boolean
 }
 


### PR DESCRIPTION
`AdCallParamValue` is an ADT, and is not used outside of this file.

This updates `AdCallParamValue` so that it is a `sealed` trait. This means the compiler can check exhaustive checking on match statements against the `sealed` trait.

@kelvin-chappell 