### PR TITLE
Add unsponsored flag

### DIFF
--- a/src/main/scala/com/gu/commercial/branding/Branding.scala
+++ b/src/main/scala/com/gu/commercial/branding/Branding.scala
@@ -12,6 +12,10 @@ case class Branding(
   aboutThisLink: String,
   hostedCampaignColour: Option[String]
 ) extends ContainerBranding {
+  // In some cases we want to prevent sponsors from being inherited from the section.
+  // To do this CP can add a "No Sponsor" sponsorship to the top tag of the series.
+  def isUnsponsored: Boolean = sponsorName.replace(" ", "").toLowerCase == "nosponsor"
+
   def isPaid: Boolean = brandingType == PaidContent
   def isSponsored: Boolean = brandingType == Sponsored
   def isFoundationFunded: Boolean = brandingType == Foundation

--- a/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/BrandingSpec.scala
@@ -41,4 +41,19 @@ class BrandingSpec extends FlatSpec with Matchers with OptionValues {
   it should "be false for non-foundation-funded content" in {
     mkBranding(PaidContent) should not be 'foundationFunded
   }
+
+  it should "not set unsponsored flag for sponsored content" in {
+    mkBranding(Sponsored).isUnsponsored shouldBe false
+  }
+
+  it should "set unsponsored flag for various permutations" in {
+    List(
+      mkBranding(Sponsored).copy(sponsorName = "No Sponsor"),
+      mkBranding(Sponsored).copy(sponsorName = "no sponsor"),
+      mkBranding(Sponsored).copy(sponsorName = "nosponsor"),
+      mkBranding(Sponsored).copy(sponsorName = "No Sponsor ")
+    ).foreach { sponsor =>
+      sponsor.isUnsponsored shouldBe true
+    }
+  }
 }


### PR DESCRIPTION
In some cases we want to prevent sponsors from being inherited from the section. To do this CP can add a "No Sponsor" sponsorship to the top tag of the series.

This is handy when we've sold sponsorship of a section and have put content that the section sponsor doesn't want in that section.