### PR TITLE
Add Scala 2.13 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scalaVersion := "2.12.4"
 crossScalaVersions := Seq("2.11.11", scalaVersion.value)
 
 libraryDependencies ++= Seq(
-  "com.gu"        %% "content-api-models-scala" % "11.38" % Provided,
+  "com.gu"        %% "content-api-models-scala" % "15.4" % Provided,
   "org.scalatest" %% "scalatest" % "3.0.3" % Test,
-  "net.liftweb"   %% "lift-json" % "3.1.1" % Test
+  "com.typesafe.play" %% "play-json" % "2.7.4" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,11 +7,11 @@ bintrayRepository := "frontend"
 
 licenses += ("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.4"
-crossScalaVersions := Seq("2.11.11", scalaVersion.value)
+scalaVersion := "2.13.1"
+crossScalaVersions := Seq(scalaVersion.value, "2.12.10", "2.11.12")
 
 libraryDependencies ++= Seq(
   "com.gu"        %% "content-api-models-scala" % "15.4" % Provided,
-  "org.scalatest" %% "scalatest" % "3.0.3" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "com.typesafe.play" %% "play-json" % "2.7.4" % Test
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")

--- a/src/main/scala/com/gu/commercial/branding/SponsorshipHelper.scala
+++ b/src/main/scala/com/gu/commercial/branding/SponsorshipHelper.scala
@@ -34,14 +34,14 @@ private[branding] object SponsorshipHelper {
   ): Option[Sponsorship] = {
     for {
       sponsorships <- section.activeSponsorships
-      sponsorship <- findRelevantSponsorship(sponsorships, edition, publishedDate)
+      sponsorship <- findRelevantSponsorship(sponsorships.toSeq, edition, publishedDate)
     } yield sponsorship
   }
 
   def findSponsorshipFromTag(tag: Tag, edition: String, publishedDate: Option[CapiDateTime]): Option[Sponsorship] = {
     for {
       sponsorships <- tag.activeSponsorships
-      sponsorship <- findRelevantSponsorship(sponsorships, edition, publishedDate)
+      sponsorship <- findRelevantSponsorship(sponsorships.toSeq, edition, publishedDate)
     } yield sponsorship
   }
 }

--- a/src/test/scala/com/gu/commercial/display/CleanerSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/CleanerSpec.scala
@@ -17,7 +17,7 @@ class CleanerSpec extends FlatSpec with Matchers {
   }
 
   it should "not contain '''" in {
-    testForIllegalCharacter(''')
+    testForIllegalCharacter('\'')
   }
 
   it should "not contain '='" in {


### PR DESCRIPTION
This PR adds Scala 2.13 support, compiling with Scala 2.13 by default, but continuing to cross-compile to Scala 2.12 & 2.11 for legacy support (tho' hopefully no projects are still using Scala 2.11!).

This PR is split into two commits, which may be a bit easier to review:

1. Replacing `lift-json` (which has no Scala 2.13 release as yet) with `play-json`
2. Small tweaks adapting to Scala 2.13 syntax, and [`Seq` changing to become immutable](https://docs.scala-lang.org/overviews/core/collections-migration-213.html#scalaseq-varargs-and-scalaindexedseq-migration).