### PR TITLE
Switch from BinTray to Sonatype/Maven Central for releasing artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: scala
 scala:
-  - 2.11.11
+  - 2.13.1
+  - 2.12.10
+  - 2.11.12
 jdk:
   - openjdk8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Commercial shared library
 
-This codebase is going to hold the business logic for the display of commercial components, so that it can be shared across all Guardian platforms: web and app.
+This codebase holds the business logic for the display of commercial components, so that it can
+be shared across all Guardian platforms: web and app.
 
 ## Assumptions
 1. It will be included in all frontend deployments that show commercial components
@@ -10,10 +11,7 @@ This codebase is going to hold the business logic for the display of commercial 
 
 ## Usage
 
-### Configuration
-1. Use bintray resolver:  
-   `resolvers += "Guardian Frontend Bintray" at "https://dl.bintray.com/guardian/frontend"`
-1. Add library as dependency:  
+Add the library as dependency:  
    `libraryDependencies += "com.gu" %% "commercial-shared" % "<x.y.z>"`
 
 ### Examples
@@ -32,12 +30,13 @@ Run the sbt `publishLocal` task.
 This will generate a local snapshot artefact.  
 Add the snapshot version as a dependency of the downstream project.
 
-### Deploy
-[You need to have an account on [bintray](https://bintray.com/) and be a member of the Guardian organisation there.  
-You also need to have run the sbt `bintrayChangeCredentials` task to generate a credentials file.]  
-Then:  
-Run the sbt `release` task.  
-This will generate artefacts and make them available from [bintray](https://bintray.com/guardian/frontend/commercial-shared).  
+### Release
+
+For Guardian Devs performing a release: make sure you're set up
+to perform releases to [Maven Central](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit?usp=sharing)!
+
+Then run the sbt `release` task.  
+
 Releases follow the [semantic versioning](http://semver.org/) policy, which is roughly:
 
 * A *major*.*minor*.*patch* format  

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,6 @@ name := "commercial-shared"
 
 organization := "com.gu"
 
-bintrayOrganization := Some("guardian")
-bintrayRepository := "frontend"
-
 licenses += ("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.13.1"
@@ -14,4 +11,21 @@ libraryDependencies ++= Seq(
   "com.gu"        %% "content-api-models-scala" % "15.4" % Provided,
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "com.typesafe.play" %% "play-json" % "2.7.4" % Test
+)
+
+import ReleaseTransformations._
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  // For cross-build projects, use releaseStepCommand("+publishSigned")
+  releaseStepCommand("sonatypeBundleRelease"),
+  setNextVersion,
+  commitNextVersion,
+  pushChanges
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,20 @@
+publishMavenStyle := true
+
+sonatypeProfileName := "com.gu"
+
+publishTo in ThisBuild := sonatypePublishToBundle.value
+
+scmInfo in ThisBuild := Some(ScmInfo(
+  url("https://github.com/guardian/commercial-shared"),
+  "scm:git:git@github.com:guardian/commercial-shared.git"
+))
+
+pomExtra in ThisBuild := {
+  <developers>
+    <developer>
+      <id>kelvin-chappell</id>
+      <name>Kelvin Chappell</name>
+      <url>https://github.com/kelvin-chappell</url>
+    </developer>
+  </developers>
+}


### PR DESCRIPTION
I've [had difficulty performing the sbt release to BinTray](https://github.com/guardian/commercial-shared/pull/43#issuecomment-551206403) - the `sbt-bintray` plugin doesn't seem to be printing out appropriate prompts when it requires the bintray username & password.

I prefer Maven Central in general (even tho' BinTray has a better web-ui!) for a few reasons, eg Maven Central enforcing immutable artifacts, and so I'm switching over here.

