### PR TITLE
Use correct default branch name in Snyk workflow

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -6,7 +6,7 @@ name: Snyk
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?
The Snyk workflow is currently using the incorrect default branch name, so we're not automatically sending results to Snyk on merges to the default branch.