### PR TITLE
Fix homepage url listed for commercial-shared

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "commercial-shared"
 
 organization := "com.gu"
 
-homepage := Some(url("https://github.com/guardian/marley"))
+homepage := Some(url("https://github.com/guardian/commercial-shared"))
 licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 
 scalaVersion := "2.13.9"


### PR DESCRIPTION
It's not https://github.com/guardian/marley !
