### PR TITLE
Upgrade content-api-models-scala to v17.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.13.9"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.10", "2.11.12")
 
 libraryDependencies ++= Seq(
-  "com.gu"        %% "content-api-models-scala" % "15.4" % Provided,
+  "com.gu"        %% "content-api-models-scala" % "17.5.1" % Provided,
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "com.typesafe.play" %% "play-json" % "2.7.4" % Test
 )

--- a/src/test/scala/com/gu/commercial/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/TestModel.scala
@@ -156,6 +156,7 @@ object TestModel {
     def internalCommissionedWordcount: Option[Int] = None
     def showAffiliateLinks: Option[Boolean] = None
     def bylineHtml: Option[String] = None
+    def showTableOfContents: Option[Boolean] = None
   }
 
   case class StubTag(
@@ -223,5 +224,6 @@ object TestModel {
     def isHosted: Boolean = false
     def pillarId: Option[String] = None
     def pillarName: Option[String] = None
+    def aliasPaths: Option[Seq[AliasPath]] = None
   }
 }


### PR DESCRIPTION

## What does this change?

Upgrade content-api-models-scala to v17.5.1, handling breaking changes to this library:

- addition of `aliasPaths` to `Content` model (introduced in [v15.9.8](https://github.com/guardian/content-api-models/releases/tag/v15.9.8) and guardian/content-api-models#186)
- addition of `showTableOfContents` to `ContentFields` (introduced in [v17.4.2](https://github.com/guardian/content-api-models/releases/tag/v17.4.2) and guardian/content-api-models#217)

## How to test

TBD...

## How can we measure success?

Fixes vulnerabilities in Thrift identified by Snyk:

- [SNYK-JAVA-ORGAPACHETHRIFT-1074898](https://app.snyk.io/org/guardian-commercial/project/fa54dd84-6fa5-40bb-897f-b86a52c566b7#issue-SNYK-JAVA-ORGAPACHETHRIFT-1074898)
- [SNYK-JAVA-ORGAPACHETHRIFT-474610](https://app.snyk.io/org/guardian-commercial/project/fa54dd84-6fa5-40bb-897f-b86a52c566b7#issue-SNYK-JAVA-ORGAPACHETHRIFT-474610)
