### PR TITLE
Add rendering platform parameter for content pages

### DIFF
--- a/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
@@ -141,6 +141,16 @@ object PlatformParam {
   def apply(value: String): PlatformParam = PlatformParam(SingleValue(value))
 }
 
+case class RenderingPlatformParam(value: SingleValue) extends AdTargetParam {
+  override val name = RenderingPlatformParam.name
+}
+
+object RenderingPlatformParam {
+  val name = "rp"
+
+  def apply(value: String): RenderingPlatformParam = RenderingPlatformParam(SingleValue(value))
+}
+
 case class SeriesParam(value: MultipleValues) extends AdTargetParam {
   override val name = SeriesParam.name
 }

--- a/src/main/scala/com/gu/commercial/display/AdTargeter.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargeter.scala
@@ -11,7 +11,7 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
     * @param item      Content item with <code>section</code> and all <code>tags</code> populated
     * @return Contextual targeting parameters to pass in display ad call
     */
-  def pageLevelTargetingForContentPage(editionId: String)(item: Content): Set[AdTargetParam] =
+  def pageLevelTargetingForContentPage(editionId: String, renderingPlatform: Option[RenderingPlatformParam] = None)(item: Content): Set[AdTargetParam] =
     Set(
       AuthorParam.from(item),
       BlogParam.from(item),
@@ -22,6 +22,7 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       ObserverParam.from(item),
       PathParam.from(item),
       Some(PlatformParam(platform)),
+      renderingPlatform,
       SeriesParam.from(item),
       ShortUrlParam.from(item),
       SurgeLevelParam.from(item, surgeLookupService),

--- a/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
@@ -50,6 +50,41 @@ class AdTargeterSpec extends FlatSpec with Matchers with OptionValues {
         "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
       )
     )
+    params.get("rp") shouldBe None
+  }
+
+  "pageLevelTargetingForContentPage with rp" should "be correct for an article" in {
+    val item   = TestModel.getContentItem("TagBrandedContent.json")
+    def targetWithRpUkEditionPage: Content => Set[AdTargetParam]    = targeter.pageLevelTargetingForContentPage("uk",  Some(RenderingPlatformParam("apps-rendering")))
+
+    val params = toMap(targetWithRpUkEditionPage(item))
+    params shouldBe Map(
+      "br"      -> SingleValue("s"),
+      "co"      -> MultipleValues(Set("dom-phillips")),
+      "ct"      -> SingleValue("article"),
+      "edition" -> SingleValue("uk"),
+      "k" -> MultipleValues(
+        Set(
+          "sustainable-business",
+          "brazil",
+          "americas",
+          "world",
+          "coffee",
+          "global-development",
+          "fair-trade",
+          "environment",
+          "northernireland"
+        )
+      ),
+      "p"  -> SingleValue("ng"),
+      "rp"  -> SingleValue("apps-rendering"),
+      "se" -> MultipleValues(Set("spotlight-on-commodities")),
+      "su" -> MultipleValues(Set("0")),
+      "tn" -> MultipleValues(Set("news")),
+      "url" -> SingleValue(
+        "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
+      )
+    )
   }
 
   it should "be correct for a video page" in {


### PR DESCRIPTION
## Why?

With the introduction of DCAR we want to start tracking which platform renders apps articles: Apps Rendering or DCR. MAPI uses this library to create targeting params, and passes them to Apps Rendering.

## What does this change?

- Adds an optional `renderingPlatform` argument to `pageLevelTargetingForContentPage` and corresponding `RenderingPlatformParam` type