### PR TITLE
Add alternative wording for US and US Exclusive sponsorship packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions := Seq("-release:11")
 crossScalaVersions := Seq(scalaVersion.value, "2.12.18")
 
 libraryDependencies ++= Seq(
-  "com.gu"        %% "content-api-models-scala" % "17.5.1" % Provided,
+  "com.gu"        %% "content-api-models-scala" % "19.0.0" % Provided,
   "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "com.typesafe.play" %% "play-json" % "2.7.4" % Test
 )

--- a/src/main/scala/com/gu/commercial/branding/Branding.scala
+++ b/src/main/scala/com/gu/commercial/branding/Branding.scala
@@ -32,6 +32,7 @@ object Branding {
       logo = Logo.make(
         title = webTitle,
         sponsorshipType = sponsorship.sponsorshipType,
+        sponsorshipPackage = sponsorship.sponsorshipPackage,
         src = sponsorship.sponsorLogo,
         dimensions = sponsorship.sponsorLogoDimensions,
         link = sponsorship.sponsorLink
@@ -40,6 +41,7 @@ object Branding {
         Logo.make(
           title = webTitle,
           sponsorshipType = sponsorship.sponsorshipType,
+          sponsorshipPackage = sponsorship.sponsorshipPackage,
           src,
           dimensions = sponsorship.highContrastSponsorLogoDimensions,
           link = sponsorship.sponsorLink

--- a/src/main/scala/com/gu/commercial/branding/Logo.scala
+++ b/src/main/scala/com/gu/commercial/branding/Logo.scala
@@ -1,6 +1,6 @@
 package com.gu.commercial.branding
 
-import com.gu.contentapi.client.model.v1.{SponsorshipLogoDimensions, SponsorshipType}
+import com.gu.contentapi.client.model.v1.{SponsorshipLogoDimensions, SponsorshipPackage, SponsorshipType}
 
 case class Logo(
   src: String,
@@ -17,6 +17,7 @@ object Logo {
   def make(
     title: String,
     sponsorshipType: SponsorshipType,
+    sponsorshipPackage: Option[SponsorshipPackage],
     src: String,
     dimensions: Option[SponsorshipLogoDimensions],
     link: String
@@ -29,6 +30,8 @@ object Logo {
         case SponsorshipType.PaidContent => "Paid for by"
         case SponsorshipType.Foundation =>
           s"${sensitiveTitles.getOrElse(title, title)} is supported by"
+        case _ if sponsorshipPackage.contains(SponsorshipPackage.Us) => "Advertising partner"
+        case _ if sponsorshipPackage.contains(SponsorshipPackage.UsExclusive) => "Exclusive advertising partner"
         case _ => "Supported by"
       }
     )

--- a/src/test/scala/com/gu/commercial/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/TestModel.scala
@@ -27,6 +27,9 @@ object TestModel {
     implicit object SponsorshipTypeNamer extends HasName[SponsorshipType] {
       def nameOf(t: SponsorshipType): String = t.name
     }
+    implicit object SponsorshipPackageNamer extends HasName[SponsorshipPackage] {
+      def nameOf(t: SponsorshipPackage): String = t.name
+    }
   }
 
   object StubJsonReads {
@@ -47,8 +50,11 @@ object TestModel {
       implicit val readsBooleanFromString = implicitly[Reads[String]].map(_.toBoolean) ; Json.reads[StubFields]
     }
 
-    implicit val readsTestSponsorship =
-      { implicit val readsType = readFrom(SponsorshipType.list) ; Json.reads[TestSponsorship] }
+    implicit val readsTestSponsorship = {
+      implicit val readsType = readFrom(SponsorshipType.list)
+      implicit val readsPackage = readFrom(SponsorshipPackage.list)
+      Json.reads[TestSponsorship]
+    }
 
     implicit val readsStubSection = Json.reads[StubSection]
 
@@ -82,6 +88,7 @@ object TestModel {
 
   case class TestSponsorship(
     sponsorshipType: SponsorshipType,
+    sponsorshipPackage: Option[SponsorshipPackage],
     sponsorName: String,
     sponsorLogo: String,
     sponsorLink: String,

--- a/src/test/scala/com/gu/commercial/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/TestModel.scala
@@ -232,5 +232,6 @@ object TestModel {
     def pillarId: Option[String] = None
     def pillarName: Option[String] = None
     def aliasPaths: Option[Seq[AliasPath]] = None
+    override def channels: Option[collection.Seq[ContentChannel]] = None
   }
 }

--- a/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
+++ b/src/test/scala/com/gu/commercial/branding/LogoSpec.scala
@@ -1,40 +1,56 @@
 package com.gu.commercial.branding
 
-import com.gu.contentapi.client.model.v1.SponsorshipType
+import com.gu.contentapi.client.model.v1.{SponsorshipPackage, SponsorshipType}
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 
 class LogoSpec extends FlatSpec with Matchers with OptionValues {
 
-  private def mkLogo(sponsorshipType: SponsorshipType, webTitle: String = "") = Logo.make(
+  private def mkLogo(sponsorshipType: SponsorshipType, sponsorshipPackage: Option[SponsorshipPackage], webTitle: String = "") = Logo.make(
     title = webTitle,
     sponsorshipType = sponsorshipType,
+    sponsorshipPackage = sponsorshipPackage,
     src = "src",
     dimensions = None,
     link = "link"
   )
 
-  "make" should "generate the correct label for sponsored content" in {
-    val logo = mkLogo(SponsorshipType.Sponsored)
+  "make" should "generate the correct label for sponsored content with unspecified sponsorship package" in {
+    val logo = mkLogo(SponsorshipType.Sponsored, None)
     logo.label shouldBe "Supported by"
   }
 
+  "make" should "generate the correct label for sponsored content with default sponsorship package" in {
+    val logo = mkLogo(SponsorshipType.Sponsored, Some(SponsorshipPackage.Default))
+    logo.label shouldBe "Supported by"
+  }
+
+  "make" should "generate the correct label for sponsored content with US sponsorship package" in {
+    val logo = mkLogo(SponsorshipType.Sponsored, Some(SponsorshipPackage.Us))
+    logo.label shouldBe "Advertising partner"
+  }
+
+  "make" should "generate the correct label for sponsored content with US exclusive package" in {
+    val logo = mkLogo(SponsorshipType.Sponsored, Some(SponsorshipPackage.UsExclusive))
+    logo.label shouldBe "Exclusive advertising partner"
+  }
+
   it should "generate the correct label for paid content" in {
-    val logo = mkLogo(SponsorshipType.PaidContent)
+    val logo = mkLogo(SponsorshipType.PaidContent, None)
     logo.label shouldBe "Paid for by"
   }
 
   it should "generate the correct label for foundation-funded content" in {
-    val logo = mkLogo(SponsorshipType.Foundation, webTitle = "Some title")
+    val logo = mkLogo(SponsorshipType.Foundation, None, webTitle = "Some title")
     logo.label shouldBe "Some title is supported by"
   }
 
   it should "generate the correct label for the special inequality foundation-funded section" in {
-    val logo = mkLogo(SponsorshipType.Foundation, webTitle = "Inequality")
+    val logo = mkLogo(SponsorshipType.Foundation, None, webTitle = "Inequality")
     logo.label shouldBe "The Inequality Project is supported by"
   }
 
   it should "generate the correct label for the special America's unequal future foundation-funded section" in {
-    val logo = mkLogo(SponsorshipType.Foundation, webTitle = "Inequality and Opportunity in America")
+    val logo = mkLogo(SponsorshipType.Foundation, None, webTitle = "Inequality and Opportunity in America")
     logo.label shouldBe "This series is supported by"
   }
 }


### PR DESCRIPTION
## What does this change?

See https://github.com/guardian/tagmanager/pull/508 for more information