### PR TITLE
pinning updated version of jackson core to 2.15.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ libraryDependencies ++= Seq(
   "org.playframework" %% "play-json" % "3.0.2" % Test
 )
 
+dependencyOverrides += "com.fasterxml.jackson.core" %% "jackson-core" % "2.15.0"
+
 import ReleaseTransformations._
 
 releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR pins the version of `jackson-core` to 2.15.0 in order to address the vulnerability in https://github.com/guardian/commercial-shared/security/dependabot/2

