### PR TITLE
Update ad targeting params

### DIFF
--- a/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
@@ -248,6 +248,19 @@ object SectionParam {
     SingleValue.fromRaw(stripEditionPrefix(path.stripPrefix("/"))) map (SectionParam(_))
 }
 
+case class SensitiveParam(value: SingleValue) extends AdTargetParam {
+  override val name = SensitiveParam.name
+}
+
+object SensitiveParam {
+  val name = "sens"
+
+  def from(item: Content): Option[SensitiveParam] = {
+    val sensitiveValue = item.fields.flatMap(_.sensitive).getOrElse(false)
+    SingleValue.fromRaw(sensitiveValue.toString) map (SensitiveParam(_))
+  }
+}
+
 case object UnknownParam extends AdTargetParam {
   override def name  = ""
   override def value = SingleValue.empty

--- a/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
@@ -224,21 +224,28 @@ case class SectionParam(value: SingleValue) extends AdTargetParam {
 object SectionParam {
   val name = "s"
 
+  private def stripEditionPrefix(id: String): String = {
+    val editions = Set("uk", "us", "au", "europe", "international")
+    val parts = id.split("/")
+    if (parts.length > 1 && editions.contains(parts.head)) {
+      parts.tail.mkString("/")
+    } else {
+      id
+    }
+  }
+
   def from(item: Content): Option[SectionParam] =
-    item.section.flatMap(section => SingleValue.fromRaw(section.id) map (SectionParam(_)))
+    item.section.flatMap(section => SingleValue.fromRaw(stripEditionPrefix(section.id)) map (SectionParam(_)))
 
   def from(section: Section): Option[SectionParam] =
-    SingleValue.fromRaw(section.id) map (SectionParam(_))
+    SingleValue.fromRaw(stripEditionPrefix(section.id)) map (SectionParam(_))
 
   def from(tag: Tag): Option[SectionParam] =
     if (tag.`type` == Type) SingleValue.fromRaw(tag.id.stripPrefix("type/")) map (SectionParam(_))
-    else SingleValue.fromRaw(tag.id.split("/").head) map (SectionParam(_))
+    else SingleValue.fromRaw(stripEditionPrefix(tag.id.split("/").head)) map (SectionParam(_))
 
-  def fromItemId(id: String): Option[SectionParam] = 
-    SingleValue.fromRaw(id.split("/").lastOption.getOrElse(id)) map (SectionParam(_))
-
-  def fromPath(path: String): Option[SectionParam] = 
-    SingleValue.fromRaw(path.stripPrefix("/")) map (SectionParam(_))
+  def fromPath(path: String): Option[SectionParam] =
+    SingleValue.fromRaw(stripEditionPrefix(path.stripPrefix("/"))) map (SectionParam(_))
 }
 
 case object UnknownParam extends AdTargetParam {

--- a/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
@@ -4,6 +4,7 @@ import com.gu.commercial.branding.{Brandable, BrandingFinder}
 import com.gu.commercial.display.Surge.bucket
 import com.gu.contentapi.client.model.v1.TagType._
 import com.gu.contentapi.client.model.v1.{Content, Section, Tag}
+import com.gu.contentapi.client.model.v1.NetworkFront
 
 sealed trait AdTargetParam {
   def name: String
@@ -214,6 +215,30 @@ object ToneParam {
   def from(tag: Tag): Option[ToneParam] =
     if (tag.`type` == Tone) MultipleValues.fromItemId(tag.id) map (ToneParam(_))
     else None
+}
+
+case class SectionParam(value: SingleValue) extends AdTargetParam {
+  override val name = SectionParam.name
+}
+
+object SectionParam {
+  val name = "s"
+
+  def from(item: Content): Option[SectionParam] =
+    item.section.flatMap(section => SingleValue.fromRaw(section.id) map (SectionParam(_)))
+
+  def from(section: Section): Option[SectionParam] =
+    SingleValue.fromRaw(section.id) map (SectionParam(_))
+
+  def from(tag: Tag): Option[SectionParam] =
+    if (tag.`type` == Type) SingleValue.fromRaw(tag.id.stripPrefix("type/")) map (SectionParam(_))
+    else SingleValue.fromRaw(tag.id.split("/").head) map (SectionParam(_))
+
+  def fromItemId(id: String): Option[SectionParam] = 
+    SingleValue.fromRaw(id.split("/").lastOption.getOrElse(id)) map (SectionParam(_))
+
+  def fromPath(path: String): Option[SectionParam] = 
+    SingleValue.fromRaw(path.stripPrefix("/")) map (SectionParam(_))
 }
 
 case object UnknownParam extends AdTargetParam {

--- a/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargetParam.scala
@@ -128,7 +128,14 @@ object PathParam {
   def fromItemId(id: String): Option[PathParam] = SingleValue.fromRaw(s"/${id.stripPrefix("/")}") map (PathParam(_))
   def from(item: Content): Option[PathParam]    = fromItemId(item.id)
   def from(section: Section): Option[PathParam] = fromItemId(section.id)
-  def from(tag: Tag): Option[PathParam]         = fromItemId(tag.id)
+  def from(tag: Tag): Option[PathParam]         = {
+    val tagId = if (tag.`type` == Type) {
+      tag.id.stripPrefix("type/")
+    } else {
+      tag.id
+    }
+    fromItemId(tagId)
+  }
 }
 
 case class PlatformParam(value: SingleValue) extends AdTargetParam {

--- a/src/main/scala/com/gu/commercial/display/AdTargeter.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargeter.scala
@@ -23,6 +23,7 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       PathParam.from(item),
       Some(PlatformParam(platform)),
       renderingPlatform,
+      SectionParam.from(item),
       SeriesParam.from(item),
       ShortUrlParam.from(item),
       SurgeLevelParam.from(item, surgeLookupService),
@@ -36,7 +37,8 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       EditionParam.from(editionId),
       KeywordParam.from(section),
       PathParam.from(section),
-      Some(PlatformParam(platform))
+      Some(PlatformParam(platform)),
+      SectionParam.from(section)
     ).flatten
 
   def pageLevelTargetingForTagPage(editionId: String)(tag: Tag): Set[AdTargetParam] = {
@@ -54,7 +56,8 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       Some(ContentTypeParam("tag")),
       EditionParam.from(editionId),
       PathParam.from(tag),
-      Some(PlatformParam(platform))
+      Some(PlatformParam(platform)),
+      SectionParam.from(tag)
     ).flatten
   }
 
@@ -64,7 +67,8 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       EditionParam.from(editionId),
       KeywordParam.fromPath(networkFrontPath),
       Some(PathParam(networkFrontPath)),
-      Some(PlatformParam(platform))
+      Some(PlatformParam(platform)),
+      SectionParam.fromPath(networkFrontPath)
     ).flatten
 
   def pageLevelTargetingForFrontUnknownToCapi(editionId: String)(frontId: String): Set[AdTargetParam] =
@@ -73,6 +77,7 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       EditionParam.from(editionId),
       KeywordParam.fromItemId(frontId),
       PathParam.fromItemId(frontId),
-      Some(PlatformParam(platform))
+      Some(PlatformParam(platform)),
+      SectionParam.fromItemId(frontId)
     ).flatten
 }

--- a/src/main/scala/com/gu/commercial/display/AdTargeter.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargeter.scala
@@ -27,7 +27,8 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       SeriesParam.from(item),
       ShortUrlParam.from(item),
       SurgeLevelParam.from(item, surgeLookupService),
-      ToneParam.from(item)
+      ToneParam.from(item),
+      SensitiveParam.from(item)
     ).flatten
 
   def pageLevelTargetingForSectionFront(editionId: String)(section: Section): Set[AdTargetParam] =

--- a/src/main/scala/com/gu/commercial/display/AdTargeter.scala
+++ b/src/main/scala/com/gu/commercial/display/AdTargeter.scala
@@ -78,6 +78,6 @@ class AdTargeter(platform: String, surgeLookupService: SurgeLookupService) {
       KeywordParam.fromItemId(frontId),
       PathParam.fromItemId(frontId),
       Some(PlatformParam(platform)),
-      SectionParam.fromItemId(frontId)
+      SectionParam.fromPath(frontId)
     ).flatten
 }

--- a/src/test/resources/TypeTag.json
+++ b/src/test/resources/TypeTag.json
@@ -1,0 +1,8 @@
+{
+    "id": "type/video",
+    "type": "type",
+    "webTitle": "Video",
+    "webUrl": "https://www.theguardian.com/video",
+    "apiUrl": "https://content.guardianapis.com/type/video",
+    "internalName": "Video (Content type)"
+}

--- a/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
@@ -182,6 +182,18 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
     )
   }
 
+  it should "be correct for a 'type' tag page" in {
+      val tag = TestModel.getTag("TypeTag.json")
+      val params = toMap(targeter.pageLevelTargetingForTagPage("uk")(tag))
+      params shouldBe Map(
+        "ct" -> SingleValue("tag"),
+        "edition" -> SingleValue("uk"),
+        "url" -> SingleValue("/video"),
+        "p" -> SingleValue("ng"),
+        // "s" -> SingleValue("video"),
+      )
+    }
+
   "pageLevelTargetingForNetworkFront" should "be correct for a network front" in {
     val params = toMap(targeter.pageLevelTargetingForNetworkFront("au")(networkFrontPath = "/us"))
     params shouldBe Map(

--- a/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
@@ -51,7 +51,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "url" -> SingleValue(
         "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
       ),
-      "s" -> SingleValue("sustainable-business")
+      "s" -> SingleValue("sustainable-business"),
+      "sens" -> SingleValue("false")
     )
     params.get("rp") shouldBe None
   }
@@ -87,7 +88,42 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "url" -> SingleValue(
         "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
       ),
-      "s" -> SingleValue("sustainable-business")
+      "s" -> SingleValue("sustainable-business"),
+      "sens" -> SingleValue("false")
+    )
+  }
+
+  "pageLevelTargetingForContentPage" should "have a correct 'sens' param" in {
+    val item   = TestModel.getContentItem("SensitiveContent.json")
+    val params = toMap(targetUkEditionPage(item))
+    params shouldBe Map(
+      "br"      -> SingleValue("s"),
+      "co"      -> MultipleValues(Set("dom-phillips")),
+      "ct"      -> SingleValue("article"),
+      "edition" -> SingleValue("uk"),
+      "k" -> MultipleValues(
+        Set(
+          "sustainable-business",
+          "brazil",
+          "americas",
+          "world",
+          "coffee",
+          "global-development",
+          "fair-trade",
+          "environment",
+          "northernireland"
+        )
+      ),
+      "p"  -> SingleValue("ng"),
+      "rp"  -> SingleValue("apps-rendering"),
+      "se" -> MultipleValues(Set("spotlight-on-commodities")),
+      "su" -> MultipleValues(Set("0")),
+      "tn" -> MultipleValues(Set("news")),
+      "url" -> SingleValue(
+        "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
+      ),
+      "s" -> SingleValue("sustainable-business"),
+      "sens" -> SingleValue("true")
     )
   }
 
@@ -103,7 +139,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "su"      -> MultipleValues(Set("5")),
       "tn"      -> MultipleValues(Set("news")),
       "url"     -> SingleValue("/technology/video/2017/feb/07/science-museum-robots-exhibition-backstage"),
-      "s"       -> SingleValue("technology")
+      "s"       -> SingleValue("technology"),
+      "sens"    -> SingleValue("false")
     )
   }
 
@@ -120,7 +157,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "su"      -> MultipleValues(Set("3", "4", "5")),
       "tn"      -> MultipleValues(Set("news")),
       "url"     -> SingleValue("/books/2016/jan/03/murder-for-christmas-mystery-of-author-francis-duncan"),
-      "s"       -> SingleValue("books")
+      "s"       -> SingleValue("books"),
+      "sens"    -> SingleValue("false")
     )
   }
 

--- a/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
+++ b/src/test/scala/com/gu/commercial/display/AdTargeterSpec.scala
@@ -50,7 +50,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "tn" -> MultipleValues(Set("news")),
       "url" -> SingleValue(
         "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
-      )
+      ),
+      "s" -> SingleValue("sustainable-business")
     )
     params.get("rp") shouldBe None
   }
@@ -85,7 +86,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "tn" -> MultipleValues(Set("news")),
       "url" -> SingleValue(
         "/sustainable-business/2017/jan/04/coffee-rainforest-alliance-utz-brazil-pesticides-exploited-workers-pay"
-      )
+      ),
+      "s" -> SingleValue("sustainable-business")
     )
   }
 
@@ -100,7 +102,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "p"       -> SingleValue("ng"),
       "su"      -> MultipleValues(Set("5")),
       "tn"      -> MultipleValues(Set("news")),
-      "url"     -> SingleValue("/technology/video/2017/feb/07/science-museum-robots-exhibition-backstage")
+      "url"     -> SingleValue("/technology/video/2017/feb/07/science-museum-robots-exhibition-backstage"),
+      "s"       -> SingleValue("technology")
     )
   }
 
@@ -116,7 +119,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "p"       -> SingleValue("ng"),
       "su"      -> MultipleValues(Set("3", "4", "5")),
       "tn"      -> MultipleValues(Set("news")),
-      "url"     -> SingleValue("/books/2016/jan/03/murder-for-christmas-mystery-of-author-francis-duncan")
+      "url"     -> SingleValue("/books/2016/jan/03/murder-for-christmas-mystery-of-author-francis-duncan"),
+      "s"       -> SingleValue("books")
     )
   }
 
@@ -129,7 +133,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("uk"),
       "k"       -> MultipleValues(Set("cities")),
       "p"       -> SingleValue("ng"),
-      "url"     -> SingleValue("/cities")
+      "url"     -> SingleValue("/cities"),
+      "s"       -> SingleValue("cities"),
     )
   }
 
@@ -141,7 +146,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("uk"),
       "k"       -> MultipleValues(Set("culture")),
       "p"       -> SingleValue("ng"),
-      "url"     -> SingleValue("/uk/culture")
+      "url"     -> SingleValue("/uk/culture"),
+      "s"       -> SingleValue("culture")
     )
   }
 
@@ -154,7 +160,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("uk"),
       "p"       -> SingleValue("ng"),
       "se"      -> MultipleValues(Set("spotlight-on-commodities")),
-      "url"     -> SingleValue("/sustainable-business/series/spotlight-on-commodities")
+      "url"     -> SingleValue("/sustainable-business/series/spotlight-on-commodities"),
+      "s"       -> SingleValue("sustainable-business")
     )
   }
 
@@ -166,7 +173,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("uk"),
       "p"       -> SingleValue("ng"),
       "se"      -> MultipleValues(Set("new-view-series")),
-      "url"     -> SingleValue("/film/series/new-view-series")
+      "url"     -> SingleValue("/film/series/new-view-series"),
+      "s"       -> SingleValue("film")
     )
   }
 
@@ -178,7 +186,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("us"),
       "k"       -> MultipleValues(Set("turkey")),
       "p"       -> SingleValue("ng"),
-      "url"     -> SingleValue("/lifeandstyle/turkey")
+      "url"     -> SingleValue("/lifeandstyle/turkey"),
+      "s"       -> SingleValue("lifeandstyle")
     )
   }
 
@@ -190,7 +199,7 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
         "edition" -> SingleValue("uk"),
         "url" -> SingleValue("/video"),
         "p" -> SingleValue("ng"),
-        // "s" -> SingleValue("video"),
+        "s" -> SingleValue("video")
       )
     }
 
@@ -201,7 +210,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("au"),
       "k"       -> MultipleValues(Set("us")),
       "p"       -> SingleValue("ng"),
-      "url"     -> SingleValue("/us")
+      "url"     -> SingleValue("/us"),
+      "s"       -> SingleValue("us")
     )
   }
 
@@ -212,7 +222,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("int"),
       "k"       -> MultipleValues(Set("us")),
       "p"       -> SingleValue("ng"),
-      "url"     -> SingleValue("/us")
+      "url"     -> SingleValue("/us"),
+      "s"       -> SingleValue("us")
     )
   }
 
@@ -224,7 +235,8 @@ class AdTargeterSpec extends AnyFlatSpec with Matchers with OptionValues {
       "edition" -> SingleValue("int"),
       "k"       -> MultipleValues(Set("tv-and-radio")),
       "p"       -> SingleValue("ng"),
-      "url"     -> SingleValue("/us/tv-and-radio")
+      "url"     -> SingleValue("/us/tv-and-radio"),
+      "s"       -> SingleValue("tv-and-radio")
     )
   }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
