### PR TITLE
Bump `content-api-models-scala` to v43.0.0 and update test stubs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions := Seq("-release:11")
 crossScalaVersions := Seq(scalaVersion.value, "2.12.19")
 
 libraryDependencies ++= Seq(
-  "com.gu"        %% "content-api-models-scala" % "19.0.1" % Provided,
+  "com.gu"        %% "content-api-models-scala" % "43.0.0" % Provided,
   "org.scalatest" %% "scalatest" % "3.2.20" % Test,
   "org.playframework" %% "play-json" % "3.0.2" % Test
 )

--- a/src/test/scala/com/gu/commercial/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/TestModel.scala
@@ -1,10 +1,11 @@
 package com.gu.commercial
 
+import com.gu.contentapi.client.model.schemaorg.SchemaOrg
+import com.gu.contentapi.client.model.v1._
+
 import java.time.LocalDateTime
 import java.time.ZoneOffset.UTC
 import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
-
-import com.gu.contentapi.client.model.v1._
 import play.api.libs.json.{Json, Reads}
 
 import scala.io.Source

--- a/src/test/scala/com/gu/commercial/TestModel.scala
+++ b/src/test/scala/com/gu/commercial/TestModel.scala
@@ -193,6 +193,7 @@ object TestModel {
     def tagCategories: Option[scala.collection.Set[String]] = None
     def campaignInformationType: Option[String] = None
     def internalName: Option[String] = None
+    def keywordType: Option[KeywordType] = None
   }
 
   case class StubElement(
@@ -232,5 +233,6 @@ object TestModel {
     def pillarName: Option[String] = None
     def aliasPaths: Option[Seq[AliasPath]] = None
     override def channels: Option[collection.Seq[ContentChannel]] = None
+    def schemaOrg: Option[SchemaOrg] = None
   }
 }


### PR DESCRIPTION
## What does this change?

- Updates `content-api-models-scala` to use version `43.0.0` 
- Updates tests with fields that have been added to `Tag` and `Content` since the previous version of this library used

## How has this change been tested?

Tested by installing the pre-release version `6.2.7-PREVIEW.health-mobbump-capi-models.2026-07-07T1113.54d818fa` in [frontend](https://github.com/guardian/frontend) and running locally

