### PR TITLE
Use v2 of gha-scala-library-release-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 name: Release
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v1
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")


### PR DESCRIPTION
## What does this change?

Upgrades to use v2 of `gha-scala-library-release-workflow`

Also removes `sbt-sonatype` from the plugins as this is no longer needed. See https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.0
